### PR TITLE
Remove base path from xref_query_tags

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -51,7 +51,6 @@
       },
       "xref_query_tags": [
         "/dotnet",
-        "/powershell",
         "/uwp/api"
       ]
     }


### PR DESCRIPTION
Fixes AB#1916936 - Remove base path from xref_query_tags