### PR TITLE
Remove unnecessary command from Partial Configurations concept

### DIFF
--- a/dsc/docs-conceptual/dsc-1.1/pull-server/partialConfigs.md
+++ b/dsc/docs-conceptual/dsc-1.1/pull-server/partialConfigs.md
@@ -287,7 +287,7 @@ configurations, combine them, and apply the resulting configuration at regular i
 specified by the **RefreshFrequencyMins** property of the LCM. If you want to force a refresh, you
 can call the
 [Update-DscConfiguration](/powershell/module/PSDesiredStateConfiguration/Update-DscConfiguration)
-cmdlet, to pull the configurations, and then `Start-DSCConfiguration –UseExisting` to apply them.
+cmdlet, to pull the configurations and apply them.
 
 ## Partial configurations in mixed push and pull modes
 


### PR DESCRIPTION
Since the ```Update-DscConfiguration``` let is *Checks the pull server for an updated configuration and applies it*, there is no need to repeat with the ```Start-DSCConfiguration –UseExisting``` cmdlet to apply the configuration.

Ref:https://docs.microsoft.com/en-us/powershell/module/PSDesiredStateConfiguration/Update-DscConfiguration?view=dsc-1.1