### PR TITLE
Add note on OS-compatibility for the WindowsFeature DSC Resource in examples

### DIFF
--- a/dsc/docs-conceptual/dsc-1.1/configurations/configurations.md
+++ b/dsc/docs-conceptual/dsc-1.1/configurations/configurations.md
@@ -1,5 +1,5 @@
 ---
-ms.date:  12/12/2018
+ms.date: 05/23/2022
 keywords:  dsc,powershell,configuration,setup
 title:  DSC Configurations
 description: DSC configurations are PowerShell scripts that define a special type of function.
@@ -35,20 +35,26 @@ A configuration script consists of the following parts:
 
 - The **Configuration** block. This is the outermost script block. You define it by using the
   **Configuration** keyword and providing a name. In this case, the name of the configuration is
-  "MyDscConfiguration".
+  `MyDscConfiguration`.
 - One or more **Node** blocks. These define the nodes (computers or VMs) that you are configuring.
-  In the above configuration, there is one **Node** block that targets a computer named "TEST-PC1".
-  The Node block can accept multiple computer names.
+  In the above configuration, there is one **Node** block that targets a computer named `TEST-PC1`.
+  The **Node** block can accept multiple computer names.
 - One or more resource blocks. This is where the configuration sets the properties for the resources
   that it is configuring. In this case, there are two resource blocks, each of which call the
-  "WindowsFeature" resource.
+  **WindowsFeature** resource.
+
+> [!NOTE]
+> The **WindowsFeature** DSC Resource is only available on Windows Server computers. For computers
+> with a client OS, like Windows 11, you need to use **WindowsOptionalFeature** instead. For more
+> information, see
+> [the "WindowsOptionalFeature" section of the PSDscResources documentation](https://github.com/PowerShell/PSDscResources#windowsoptionalfeature).
 
 Within a **Configuration** block, you can do anything that you normally could in a PowerShell
-function. For example, in the previous example, if you didn't want to hard code the name of the
-target computer in the configuration, you could add a parameter for the node name:
+function. In the previous example, if you didn't want to hard code the name of the target computer
+in the configuration, you could add a parameter for the node name.
 
 In this example, you specify the name of the node by passing it as the **ComputerName** parameter
-when you compile the configuration. The name defaults to "localhost".
+when you compile the configuration. The name defaults to `localhost`.
 
 ```powershell
 Configuration MyDscConfiguration
@@ -85,8 +91,8 @@ block.
 MyDscConfiguration -ComputerName "localhost", "Server01"
 ```
 
-When specifying a list of computers to the **Node** block, from within a Configuration, you need to
-use array-notation.
+When specifying a list of computers to the **Node** block, from within a **Configuration**, you need
+to use array-notation.
 
 ```powershell
 Configuration MyDscConfiguration

--- a/dsc/docs-conceptual/dsc-3.0/concepts/configurations.md
+++ b/dsc/docs-conceptual/dsc-3.0/concepts/configurations.md
@@ -1,6 +1,6 @@
 ---
 description: DSC configurations are PowerShell scripts that define a special type of function.
-ms.date: 12/16/2021
+ms.date: 05/23/2022
 title: DSC Configurations
 ---
 # Configurations
@@ -33,11 +33,17 @@ A configuration script consists of the following parts:
   **WindowsFeature** resource.
 
 Within a **Configuration** block, you can do anything that you normally could in a PowerShell
-function. For example, in the previous example, if you didn't want to hard code the name of the
+function. In the previous example, if you didn't want to hard code the name of the
 Windows feature in the configuration, you could add a parameter.
 
 In this example, you specify the name of the feature by passing it as the **WindowsFeature**
-parameter when you compile the configuration. The name defaults to "RSAT".
+parameter when you compile the configuration. The name defaults to `RSAT`.
+
+> [!NOTE]
+> The **WindowsFeature** DSC Resource is only available on Windows Server computers. For computers
+> with a client OS, like Windows 11, you need to use **WindowsOptionalFeature** instead. For more
+> information, see
+> [the "WindowsOptionalFeature" section of the PSDscResources documentation](https://github.com/PowerShell/PSDscResources#windowsoptionalfeature).
 
 ```powershell
 Configuration MyDscConfiguration


### PR DESCRIPTION
I was testing this on a Win11 machine, got confused by the resulting error "The term 'WindowsFeature' is not recognized as a name of a cmdlet, function, script file, or executable program." This was due to WindowsFeature not being a client-side component.

# PR Summary
<!--
    Summarize your changes and list related issues here. For example:

    This change fixes problem X in the documentation for Issue #Y.
    - Fixes #1234
    - Fixes #1235
-->

## PR Context

Check the boxes below to indicate the content affected by this PR.

<!-- To mark a checkbox, use [x]. -->

**Repository or docset configuration**
- [ ] Repo documentation and configuration (.git/.github/.vscode etc.)
- [ ] Docs build files (.openpublishing.* and build scripts)
- [ ] Docset configuration (docfx.json, mapping, bread, module folder)

**Conceptual documentation**
- [x] Files in docs-conceptual

**Cmdlet reference & about_ topics**
When changing **cmdlet reference** or **about_ topics**, the changes should be copied to all
relevant versions. Check the boxes below to indicate the versions affected by this change.

- [ ] Version 3.0 content
- [ ] Version 2.0 content
- [ ] Version 1.1 content

## PR Checklist

- [ ] I have read the [contributors guide][contrib] and followed the style and process guidelines
- [ ] PR has a meaningful title
- [ ] PR is targeted at the _main_ branch
- [ ] All relevant versions updated
- [ ] Includes content related to issues and PRs - see [Closing issues using keywords][key].
- [ ] This PR is ready to merge and is not **Work in Progress**. If the PR is work in progress,
  please add the prefix `WIP:` or `[WIP]` to the beginning of the title and remove the prefix when
  the PR is ready.

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[key]: https://help.github.com/en/articles/closing-issues-using-keywords
