### PR TITLE
(AB#4072) Add stale content reporting

### DIFF
--- a/.github/workflows/stale-content.yml
+++ b/.github/workflows/stale-content.yml
@@ -1,0 +1,33 @@
+# This workflow inspects the specified relative folder path for stale documents,
+# defined as any markdown files with an `ms.date` key whose value is more than
+# 330 days from the time this workflow is run.
+#
+# It ignores the folders in the exclude_path_segment input as those documents
+# are not expected to be fresh at this time.
+name: Reporting
+on:
+  schedule:
+    # midnight UTC on the first of every month
+    - cron: 0 0 1 * *
+permissions:
+  contents: read
+jobs:
+  Report:
+    name: Stale Content
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout Repository
+        id: checkout_repo
+        uses: actions/checkout@v3
+      - name: Write Report
+        uses: MicrosoftDocs/PowerShell-Docs/.github/actions/reporting/stale-content/v1@main
+        with:
+          relative_folder_path: |
+            dsc/docs-conceptual
+          # Ignore legacy DSC documentation as it is functionally code-frozen.
+          exclude_folder_segment: |
+            dsc-1.1
+          upload_artifact: true


### PR DESCRIPTION
# PR Summary

This change adds monthly reporting to the repository to inspect the conceptual documentation for stale content (defined as anything with an `ms.date` value more than 330 days older than the current date), writing the report in the console logs, to the GitHub Action summary, and uploading the data in CSV format as a GitHub Action artifact.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide