### PR TITLE
Update msft-dsclocalconfigurationmanager-performrequiredconfigurationchecks.md

### DIFF
--- a/dsc/docs-conceptual/dsc-1.1/reference/mof-classes/msft-dsclocalconfigurationmanager-performrequiredconfigurationchecks.md
+++ b/dsc/docs-conceptual/dsc-1.1/reference/mof-classes/msft-dsclocalconfigurationmanager-performrequiredconfigurationchecks.md
@@ -6,7 +6,7 @@ description: PerformRequiredConfigurationChecks method
 ---
 # PerformRequiredConfigurationChecks method
 
-Starts a consistency check by using the Task Scheduler.
+Starts a consistency check.
 
 ## Syntax
 


### PR DESCRIPTION
The main statement at the beginning of the article is simply wrong: "Starts a consistency check by using the Task Scheduler". This should rather simply state "Starts a consistency check".

This method has nothing to do with the Task Scheduler anymore, as there is no DSC task anymore (there was, a long time ago). The firing of consistency checks is now handled through DscTimer.dll hosted in the "main" WmiPrvSE.exe process (hosting cimwin32.dll & others), but this method is also called by Update-DscConfiguration or Start-DscConfiguration cmdlets & you can also execute it manually whenever you want directly via WMI.