### PR TITLE
(AB#5227) Address machine config limits for DSC Resources

### DIFF
--- a/dsc/docs-conceptual/dsc-2.0/concepts/configurations.md
+++ b/dsc/docs-conceptual/dsc-2.0/concepts/configurations.md
@@ -5,24 +5,29 @@ title:  DSC Configurations
 description: >
   DSC configurations are PowerShell scripts that define a special kind of command.
 ---
+
 # DSC Configurations
 
-> Applies To: PowerShell 7.2
+> Applies To: PowerShell 7.2, Azure Policy's machine configuration feature
 
 DSC Configurations are PowerShell scripts that define a special kind of command. To define a
 Configuration, use the PowerShell keyword `configuration`.
 
 ```powershell
 Configuration MyDscConfiguration {
-    WindowsFeature MyFeatureInstance {
+    Environment FirstEnvironmentVariable {
         Ensure = 'Present'
-        Name = 'RSAT'
+        Name   = 'Foo'
+        Value  = 'Example'
     }
-    WindowsFeature My2ndFeatureInstance {
+
+    Environment SecondEnvironmentVariable {
         Ensure = 'Present'
-        Name = 'Bitlocker'
+        Name   = 'Bar'
+        Value  = 'Another'
     }
 }
+
 MyDscConfiguration
 ```
 
@@ -37,19 +42,13 @@ A DSC Configuration script consists of the following parts:
   `MyDscConfiguration`.
 - One or more DSC Resource blocks. This is where the DSC Configuration defines the settings for the
   software it's configuring. In this case, there are two DSC Resource blocks. They both use the
-  `WindowsFeature` DSC Resource.
-
-> [!NOTE]
-> The `WindowsFeature` DSC Resource is only available on Windows Server computers. For computers
-> with a client OS, like Windows 11, you need to use `WindowsOptionalFeature` instead. For more
-> information, see
-> [the "WindowsOptionalFeature" in the PSDscResources documentation][1].
+  `Environment` DSC Resource.
 
 ## Compiling the configuration
 
 Before you can use a DSC Configuration, you have to compile it into a MOF document. You do this by
-calling the DSC Configuration like you would call a PowerShell function. The last line of the example,
-containing only the name of the DSC Configuration, executes the DSC Configuration.
+calling the DSC Configuration like you would call a PowerShell function. The last line of the
+example, containing only the name of the DSC Configuration, executes the DSC Configuration.
 
 > [!NOTE]
 > To call a DSC Configuration, it must be loaded in the current scope (as with any other PowerShell
@@ -72,7 +71,7 @@ When you call the DSC Configuration, it:
 If you ran the previous examples, you might have noticed that you were warned that you were using a
 resource without explicitly importing it.
 
-You can use the [Get-DscResource][2] cmdlet to determine what resources are installed on the
+You can use the [Get-DscResource][1] cmdlet to determine what resources are installed on the
 system and available for use. Even when their modules have been placed in `$env:PSModulePath` and
 are recognized by `Get-DscResource`, they still need to be loaded within your DSC Configuration.
 
@@ -85,7 +84,13 @@ block. It's not a cmdlet. `Import-DscResource` supports two parameters:
   **Name** property of `Get-DscResource`'s return object, but the class name used when defining the
   resource schema (the **ResourceType** property of the object returned by `Get-DscResource`).
 
-For more information on using `Import-DSCResource`, see [Using Import-DSCResource][3]
+For more information on using `Import-DSCResource`, see [Using Import-DSCResource][2]
+
+> [!IMPORTANT]
+> There's a limitation in machine configuration that prevents a DSC Resource from using any
+> PowerShell cmdlets not included in PowerShell itself or in a module on the PowerShell Gallery.
+> DSC Resources that use cmdlets from one or more [Windows modules][3] won't work in machine
+> configuration.
 
 ## See Also
 
@@ -94,8 +99,8 @@ For more information on using `Import-DSCResource`, see [Using Import-DSCResourc
 
 <!-- Reference Links -->
 
-[1]: https://github.com/PowerShell/PSDscResources#windowsoptionalfeature
-[2]: /powershell/module/PSDesiredStateConfiguration/Get-DscResource
-[3]: import-dscresource.md
+[1]: /powershell/module/PSDesiredStateConfiguration/Get-DscResource
+[2]: import-dscresource.md
+[3]: /powershell/windows/module-compatibility#module-list
 [4]: ../overview.md
 [5]: resources.md

--- a/dsc/docs-conceptual/dsc-2.0/concepts/get-test-set.md
+++ b/dsc/docs-conceptual/dsc-2.0/concepts/get-test-set.md
@@ -11,8 +11,8 @@ description: >
 > Applies To: PowerShell 7.2
 
 DSC is constructed around a **Get**, **Test**, and **Set** process. [DSC Resources][1] are
-implemented to complete each of these operations. In a [DSC Configuration][2], you define DSC Resource
-blocks to fill in properties that define the desired state for that DSC Resource.
+implemented to complete each of these operations. In a [DSC Configuration][2], you define DSC
+Resource blocks to fill in properties that define the desired state for that DSC Resource.
 
 You can inspect a DSC Resource to see the properties it can manage with the `Get-DscResource`
 cmdlet.
@@ -58,7 +58,7 @@ TerminateTimeout     [UInt32]             False {}
 ## Get
 
 The **Get** method of a DSC Resource retrieves the current state of that DSC Resource on the system.
-This state is returned as a [hashtable][4]. The keys of the **hashtable** are the resource's
+This state is returned as a [hashtable][3]. The keys of the **hashtable** are the resource's
 properties.
 
 This is sample output from calling `Invoke-DscResource` with the **Get** method for the `Service`
@@ -169,12 +169,11 @@ reboot is required.
 
 ## See also
 
-- [Azure Automation DSC Overview][5]
+- [Azure Automation DSC Overview][4]
 
 <!-- Reference Links -->
 
 [1]: resources.md
 [2]: configurations.md
-[3]: /windows/desktop/wmisdk/managed-object-format--mof-
-[4]: /powershell/module/microsoft.powershell.core/about/about_hash_tables
-[5]: /azure/automation/automation-dsc-overview
+[3]: /powershell/module/microsoft.powershell.core/about/about_hash_tables
+[4]: /azure/automation/automation-dsc-overview

--- a/dsc/docs-conceptual/dsc-2.0/concepts/import-dscresource.md
+++ b/dsc/docs-conceptual/dsc-2.0/concepts/import-dscresource.md
@@ -9,7 +9,9 @@ description: >
 
 # Using Import-DSCResource
 
-`Import-DSCResource` is a dynamic keyword, which can only be used inside a `configuration` block to
+> Applies To: PowerShell 7.2, Azure Policy's machine configuration feature
+
+`Import-DSCResource` is a dynamic keyword, which can only be used inside a `Configuration` block to
 import any resources needed in your DSC Configuration. DSC Resources under `$PSHOME` are imported
 automatically, but it's best practice to explicitly import all DSC Resources used in your
 [DSC Configuration][1].
@@ -35,27 +37,29 @@ Parameters
   parameter. By default, the latest available version of the DSC Resource is imported.
 
 ```powershell
-Import-DscResource -ModuleName xActiveDirectory
+Import-DSCResource -ModuleName xActiveDirectory
 ```
 
 ## Example: Use Import-DSCResource within a DSC Configuration
 
 ```powershell
 Configuration MSDSCConfiguration {
-    # Search for and imports three DSC Resources from the xPSDesiredStateConfiguration module.
-    Import-DSCResource -ModuleName xPSDesiredStateConfiguration -Name Service, RemoteFile, Registry
+    # Search for and imports two DSC Resources from the PSDscResources module.
+    Import-DSCResource -ModuleName PSDscResources -Name Service, Registry
 
-    # Search for and import Resource1 from the module that defines it.
-    # If only -Name parameter is used then resources can belong to different PowerShell modules as well.
-    # TimeZone resource is from the ComputerManagementDSC module which is not installed by default.
-    # As a best practice, list each requirement on a different line if possible.  This makes reviewing
-    # multiple changes in source control a bit easier.
-    Import-DSCResource -Name Registry
+    # Search for and import Resource1 from the module that defines it. If only
+    # the -Name parameter is used then resources can belong to different
+    # PowerShell modules as well. TimeZone resource is from the
+    # ComputerManagementDSC module which is not installed by default. As a best
+    # practice, list each requirement on a different line if possible.  This
+    # makes reviewing  multiple changes in source control a bit easier.
+    Import-DSCResource -Name Service
     Import-DSCResource -Name TimeZone
 
-    # Search for and import all DSC resources inside the Module xPSDesiredStateConfiguration.
-    # When specifying the ModuleName parameter, it is a requirement to list each on a new line.
-    Import-DSCResource -ModuleName xPSDesiredStateConfiguration
+    # Search for and import all DSC resources inside the PSDscResources module.
+    # When specifying the ModuleName parameter, it is a requirement to list each
+    # on a new line.
+    Import-DSCResource -ModuleName PSDscResources
     # You can specify a ModuleVersion parameter
     Import-DSCResource -ModuleName ComputerManagementDsc -ModuleVersion 6.0.0.0
 ...
@@ -68,7 +72,7 @@ Configuration MSDSCConfiguration {
 > during compilation.
 >
 > ```powershell
-> Import-DscResource -Name UserConfigProvider*,TestLogger1 -ModuleName UserConfigProv,PsModuleForTestLogger
+> Import-DSCResource -Name Service, TimeZone -ModuleName PSDscResources, xPSDesiredStateConfiguration
 > ```
 
 Things to consider when using only the **Name** parameter:
@@ -113,11 +117,11 @@ Consider the following DSC Configuration:
 
 ```powershell
 Configuration SchemaValidationInCorrectEnumValue {
-    Import-DSCResource -Name WindowsFeature -Module PSDscResources
+    Import-DSCResource -Name User -Module PSDscResources
 
-    WindowsFeature ROLE1 {
-        Name   = 'Telnet-Client'
-        Ensure = 'Invalid'
+    User ExampleUser {
+        UserName = 'ExampleDscUser'
+        Ensure   = 'Invalid'
     }
 }
 ```
@@ -125,15 +129,16 @@ Configuration SchemaValidationInCorrectEnumValue {
 Compiling this DSC Configuration results in an error.
 
 ```Output
-Write-Error: C:\code\dsc\Sample.ps1:4
+Write-Error: C:\code\dsc\sample.ps1:4:5
 Line |
-   4 |          WindowsFeature ROLE1
-     |          ~~~~~~~~~~~~~~
-     | At least one of the values 'Invalid' is not supported or valid for property
-     | 'Ensure' on class 'WindowsFeature'. Please specify only supported values:
-     | Present, Absent.
+   4 |      User ExampleUser {
+     |      ~~~~
+     | At least one of the values 'Invalid' is not supported or   
+     | valid for property 'Ensure' on class 'User'. Please specify
+     | only supported values: Present, Absent.
 
-InvalidOperation: Errors occurred while processing configuration 'SchemaValidationInCorrectEnumValue'.
+InvalidOperation: Errors occurred while processing configuration
+'SchemaValidationInCorrectEnumValue'.
 ```
 
 IntelliSense and schema validation allow you to catch more errors during parse and compilation time,
@@ -141,15 +146,15 @@ avoiding future complications.
 
 > [!NOTE]
 > Each DSC Resource can have a name and a **FriendlyName** defined by the DSC Resource's schema.
-> Below are the first two lines of `MSFT_ServiceResource.shema.mof`.
+> Below are the first two lines of `MSFT_UserResource.schema.mof`.
 >
 > ```syntax
-> [ClassVersion("1.0.0"),FriendlyName("Service")]
-> class MSFT_ServiceResource : OMI_BaseResource
+> [ClassVersion("1.0.0"), FriendlyName("User")]
+> class MSFT_UserResource : OMI_BaseResource
 > ```
 >
-> When using this DSC Resource in a `Configuration` block, you can specify **MSFT_ServiceResource**
-> or **Service**.
+> When using this DSC Resource in a `Configuration` block, you can specify `MSFT_UserResource` or
+> `User`.
 
 ## See also
 

--- a/dsc/docs-conceptual/dsc-2.0/getting-started/invoking-dsc-resources.md
+++ b/dsc/docs-conceptual/dsc-2.0/getting-started/invoking-dsc-resources.md
@@ -9,6 +9,8 @@ description: >
 
 # Get started with invoking DSC resources
 
+> Applies To: PowerShell 7.2
+
 This topic explains how to get started using PowerShell Desired State Configuration (DSC) with the
 `Invoke-DscResource` cmdlet.
 

--- a/dsc/docs-conceptual/dsc-2.0/how-tos/configurations/depends-on.md
+++ b/dsc/docs-conceptual/dsc-2.0/how-tos/configurations/depends-on.md
@@ -10,6 +10,8 @@ description: >
 
 # Managing dependencies in DSC Configurations
 
+> Applies To: PowerShell 7.2, Azure Policy's machine configuration feature
+
 When you write [DSC Configurations][1] for [Azure Policy's machine configuration feature][2], you
 add [Resource blocks][3] to configure aspects of a system. As you continue to add DSC Resource
 blocks, your DSC Configurations can grow large and cumbersome to manage. One such challenge is the
@@ -26,41 +28,26 @@ array of strings with the following syntax.
 DependsOn = '[<Resource Type>]<Resource Name>', '[<Resource Type>]<Resource Name>'
 ```
 
-The following example configures a firewall rule after enabling and configuring the public profile.
+The following example configures a group's membership after creating a user.
 
 ```powershell
-# Install the NetworkingDSC module to configure firewall rules and profiles.
-Install-Module -Name NetworkingDSC
+Configuration ConfigureExampleUserGroup {
+    Import-DSCResource -Name User, Group -Module PSDscResources
 
-Configuration ConfigureFirewall {
-    # It's best practice to explicitly import required resources and modules.
-    Import-DSCResource -Name Firewall, FirewallProfile -Module NetworkingDsc
-
-    Firewall Firewall {
-        Name                  = 'IIS-WebServerRole-HTTP-In-TCP'
-        Ensure                = 'Present'
-        Enabled               = 'True'
-        DependsOn             = '[FirewallProfile]FirewallProfilePublic'
+    Group Example {
+        GroupName = 'DscExampleGroup'
+        Members   = 'DscExampleUser'
+        DependsOn = '[User]Example'
     }
 
-    FirewallProfile FirewallProfilePublic {
-        Name                    = 'Public'
-        Enabled                 = 'True'
-        DefaultInboundAction    = 'Block'
-        DefaultOutboundAction   = 'Allow'
-        AllowInboundRules       = 'True'
-        AllowLocalFirewallRules = 'False'
-        AllowLocalIPsecRules    = 'False'
-        NotifyOnListen          = 'True'
-        LogFileName             = '%systemroot%\system32\LogFiles\Firewall\pfirewall.log'
-        LogMaxSizeKilobytes     = 16384
-        LogAllowed              = 'False'
-        LogBlocked              = 'True'
-        LogIgnored              = 'NotConfigured'
+    User Example {
+        UserName    = 'DscExampleUser'
+        Ensure      = 'Present'
+        Description = 'Example user who should be a member of DscExampleGroup.'
     }
 }
 
-ConfigureFirewall -OutputPath C:\Temp\
+ConfigureExampleUserGroup
 ```
 
 <!-- Reference Links -->

--- a/dsc/docs-conceptual/dsc-2.0/how-tos/configurations/write-and-compile.md
+++ b/dsc/docs-conceptual/dsc-2.0/how-tos/configurations/write-and-compile.md
@@ -6,9 +6,10 @@ description: >
   This exercise walks through creating and compiling a DSC Configuration from start to finish. In
   the following example, you will learn how to write and compile a minimal Configuration
 ---
+
 # Write and compile a DSC Configuration
 
-> Applies To: PowerShell 7.2
+> Applies To: PowerShell 7.2, Azure Policy's machine configuration feature
 
 This exercise walks through creating and compiling a DSC Configuration from start to finish. In the
 following example, you'll learn how to write and compile a minimal DSC Configuration to ensure a

--- a/dsc/docs-conceptual/dsc-2.0/how-tos/installing-dsc-resources.md
+++ b/dsc/docs-conceptual/dsc-2.0/how-tos/installing-dsc-resources.md
@@ -8,6 +8,8 @@ description: >
 
 # Installing DSC Resources
 
+> Applies To: PowerShell 7.2
+
 Before you write a DSC Resource to solve your problem, you should look through the DSC Resources
 that have already been created by both Microsoft and the PowerShell community.
 

--- a/dsc/docs-conceptual/dsc-2.0/how-tos/resources/authoring/checklist.md
+++ b/dsc/docs-conceptual/dsc-2.0/how-tos/resources/authoring/checklist.md
@@ -8,6 +8,8 @@ description: >
 ---
 # DSC Resource authoring checklist
 
+> Applies To: PowerShell 7.2
+
 This checklist is a list of best practices when authoring a new DSC Resource.
 
 ## Module contains a manifest

--- a/dsc/docs-conceptual/dsc-2.0/how-tos/resources/authoring/single-instance.md
+++ b/dsc/docs-conceptual/dsc-2.0/how-tos/resources/authoring/single-instance.md
@@ -9,6 +9,8 @@ description: >
 
 # Authoring a single-instance DSC Resource
 
+> Applies To: PowerShell 7.2
+
 > [!NOTE]
 > This article describes a best practice for defining a DSC resource that allows only a single
 > instance in a DSC Configuration. There is no built-in DSC feature to do this. That might change in

--- a/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/WindowsFeature/Example.md
+++ b/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/WindowsFeature/Example.md
@@ -70,4 +70,15 @@ ensure a Windows Feature is installed or installed with user-provided settings.
 By default, it ensures the `Telnet-Client` Windows feature is installed without subfeatures and
 doesn't write the installation logs to a file.
 
+> [!IMPORTANT]
+> There's a limitation in machine configuration that prevents a DSC Resource from using any
+> PowerShell cmdlets not included in PowerShell itself or in a module on the PowerShell Gallery.
+> This example is provided for demonstrative purposes, but because the DSC Resource uses cmdlets
+> from the DISM module, which ships as one of the [Windows modules][1], it won't work in machine
+> configuration.
+
 :::code source="Example.Config.ps1":::
+
+<!-- Reference Links -->
+
+[1]: /powershell/windows/module-compatibility#module-list

--- a/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/WindowsFeatureSet/Install.md
+++ b/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/WindowsFeatureSet/Install.md
@@ -31,8 +31,16 @@ This snippet shows how you can define a `Configuration` with a `WindowsFeatureSe
 ensure that the `Telnet-Client` and `RSAT-File-Services` Windows features are installed with their
 subfeatures.
 
+> [!IMPORTANT]
+> There's a limitation in machine configuration that prevents a DSC Resource from using any
+> PowerShell cmdlets not included in PowerShell itself or in a module on the PowerShell Gallery.
+> This example is provided for demonstrative purposes, but because the DSC Resource uses cmdlets
+> from the DISM module, which ships as one of the [Windows modules][2], it won't work in machine
+> configuration.
+
 :::code source="Install.Config.ps1":::
 
 <!-- Reference Links -->
 
 [1]: ../WindowsFeature/WindowsFeature.md
+[2]: /powershell/windows/module-compatibility#module-list

--- a/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/WindowsFeatureSet/Uninstall.md
+++ b/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/WindowsFeatureSet/Uninstall.md
@@ -32,8 +32,16 @@ This snippet shows how you can define a `Configuration` with a `WindowsFeatureSe
 ensure that the `Telnet-Client` and `RSAT-File-Services` Windows features and their subfeatures are
 uninstalled.
 
+> [!IMPORTANT]
+> There's a limitation in machine configuration that prevents a DSC Resource from using any
+> PowerShell cmdlets not included in PowerShell itself or in a module on the PowerShell Gallery.
+> This example is provided for demonstrative purposes, but because the DSC Resource uses cmdlets
+> from the DISM module, which ships as one of the [Windows modules][2], it won't work in machine
+> configuration.
+
 :::code source="Uninstall.Config.ps1":::
 
 <!-- Reference Links -->
 
 [1]: ../WindowsFeature/WindowsFeature.md
+[2]: /powershell/windows/module-compatibility#module-list

--- a/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/WindowsOptionalFeature/Enable.md
+++ b/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/WindowsOptionalFeature/Enable.md
@@ -39,4 +39,15 @@ This script shows how you can use the `WindowsOptionalFeature` resource with the
 This snippet shows how you can define a `Configuration` with a `WindowsOptionalFeature` resource
 block to ensure a user-specified feature is enabled.
 
+> [!IMPORTANT]
+> There's a limitation in machine configuration that prevents a DSC Resource from using any
+> PowerShell cmdlets not included in PowerShell itself or in a module on the PowerShell Gallery.
+> This example is provided for demonstrative purposes, but because the DSC Resource uses cmdlets
+> from the DISM module, which ships as one of the [Windows modules][1], it won't work in machine
+> configuration.
+
 :::code source="Enable.Config.ps1":::
+
+<!-- Reference Links -->
+
+[1]: /powershell/windows/module-compatibility#module-list

--- a/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/WindowsOptionalFeatureSet/Disable.md
+++ b/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/WindowsOptionalFeatureSet/Disable.md
@@ -31,8 +31,16 @@ This snippet shows how you can define a `Configuration` with a `WindowsOptionalF
 block to ensure that the `MicrosoftWindowsPowerShellV2` and `Internet-Explorer-Optional-amd64`
 Windows optional features are disabled.
 
+> [!IMPORTANT]
+> There's a limitation in machine configuration that prevents a DSC Resource from using any
+> PowerShell cmdlets not included in PowerShell itself or in a module on the PowerShell Gallery.
+> This example is provided for demonstrative purposes, but because the DSC Resource uses cmdlets
+> from the DISM module, which ships as one of the [Windows modules][2], it won't work in machine
+> configuration.
+
 :::code source="Disable.Config.ps1":::
 
 <!-- Reference Links -->
 
 [1]: ../WindowsOptionalFeature/WindowsOptionalFeature.md
+[2]: /powershell/windows/module-compatibility#module-list

--- a/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/WindowsOptionalFeatureSet/Enable.md
+++ b/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/WindowsOptionalFeatureSet/Enable.md
@@ -31,8 +31,16 @@ This snippet shows how you can define a `Configuration` with a `WindowsOptionalF
 block to ensure that the `MicrosoftWindowsPowerShellV2` and `Internet-Explorer-Optional-amd64`
 Windows optional features are enabled.
 
+> [!IMPORTANT]
+> There's a limitation in machine configuration that prevents a DSC Resource from using any
+> PowerShell cmdlets not included in PowerShell itself or in a module on the PowerShell Gallery.
+> This example is provided for demonstrative purposes, but because the DSC Resource uses cmdlets
+> from the DISM module, which ships as one of the [Windows modules][2], it won't work in machine
+> configuration.
+
 :::code source="Enable.Config.ps1":::
 
 <!-- Reference Links -->
 
 [1]: ../WindowsOptionalFeature/WindowsOptionalFeature.md
+[2]: /powershell/windows/module-compatibility#module-list

--- a/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/WindowsPackageCab/Install.md
+++ b/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/WindowsPackageCab/Install.md
@@ -43,4 +43,15 @@ cmdlet to ensure a user-specified package is installed.
 This snippet shows how you can define a `Configuration` with a `WindowsPackageCab` resource block to
 ensure a user-specified package is installed.
 
+> [!IMPORTANT]
+> There's a limitation in machine configuration that prevents a DSC Resource from using any
+> PowerShell cmdlets not included in PowerShell itself or in a module on the PowerShell Gallery.
+> This example is provided for demonstrative purposes, but because the DSC Resource uses cmdlets
+> from the DISM module, which ships as one of the [Windows modules][1], it won't work in machine
+> configuration.
+
 :::code source="Install.Config.ps1":::
+
+<!-- Reference Links -->
+
+[1]: /powershell/windows/module-compatibility#module-list

--- a/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/overview.md
+++ b/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/overview.md
@@ -62,7 +62,7 @@ comments.
 - [WindowsProcess][22]: Start or stop a Windows process.
 - [ProcessSet][23]: Manage multiple Windows processes with common settings.
 
-### Resources that Work on Nano Server
+### Resources that work on Nano Server
 
 - [Group][9]
 - [Script][13]
@@ -71,6 +71,21 @@ comments.
 - [WindowsOptionalFeature][19]
 - [WindowsOptionalFeatureSet][20]
 - [WindowsPackageCab][21]
+
+### Resources that don't work in machine configuration
+
+When using Azure Policy's machine configuration feature, don't use the following resources:
+
+- `WindowsFeature`
+- `WindowsFeatureSet`
+- `WindowsOptionalFeature`
+- `WindowsOptionalFeatureSet`
+- `WindowsPackageCab`
+
+There's a limitation in machine configuration that prevents a DSC Resource from using any PowerShell
+cmdlets not included in PowerShell itself or in a module on the PowerShell Gallery. These DSC
+Resources use cmdlets from one or more [Windows modules][24] and won't work in machine
+configuration.
 
 <!-- Reference Links -->
 
@@ -97,3 +112,4 @@ comments.
 [21]: Resources/WindowsPackageCab/WindowsPackageCab.md
 [22]: Resources/WindowsProcess/WindowsProcess.md
 [23]: Resources/ProcessSet/ProcessSet.md
+[24]: /powershell/windows/module-compatibility#module-list


### PR DESCRIPTION
# PR Summary

There is a known limitation in machine configuration which prevents users from using DSC Resources which call any cmdlets which are not included in PowerShell itself or available from a module on the Gallery. This includes the built-in Windows modules, like **DISM**.

This change updates the documentation to:

- Alert readers to this limitation where sensible
- Replace examples in the conceptual docs which point to DSC Resources that won't work in machine configuration with ones that will
- Ensure all conceptual docs which apply only to machine configuration say so at the top of the document.

This change fixes [AB#5227](https://dev.azure.com/content-learn/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/5227).

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide