### PR TITLE
(AB#5130) Update feedback URLs in DocFX

### DIFF
--- a/dsc/docfx.json
+++ b/dsc/docfx.json
@@ -30,7 +30,7 @@
       "breadcrumb_path": "/powershell/dsc/breadcrumb/toc.json",
       "extendBreadcrumb": true,
       "feedback_github_repo": "MicrosoftDocs/PowerShell-Docs-DSC",
-      "feedback_product_url": "https://support.microsoft.com/windows/send-feedback-to-microsoft-with-the-feedback-hub-app-f59187f8-8739-22d6-ba93-f66612949332",
+      "feedback_product_url": "https://github.com/PowerShell/PSDesiredStateConfiguration/issues/new/choose",
       "feedback_system": "GitHub",
       "hideScope": false,
       "ms.author": "sewhee",
@@ -42,7 +42,12 @@
       ],
       "titleSuffix": "PowerShell",
       "toc_preview": true,
-      "uhfHeaderId": "MSDocsHeader-Powershell",
+      "uhfHeaderId": "MSDocsHeader-Powershell"
+    },
+    "fileMetadata": {
+      "feedback_product_url": {
+        "**/dsc-1.1/**/*.md": "https://support.microsoft.com/windows/send-feedback-to-microsoft-with-the-feedback-hub-app-f59187f8-8739-22d6-ba93-f66612949332"
+      }
     },
     "markdownEngineName": "markdig",
     "overwrite": [],


### PR DESCRIPTION
# PR Summary

Prior to this change, the DocFX configuration for this repository used the generic feedback hub for all product feedback on DSC (separate from the docs feedback).

This change:

- Sets the default product feedback URL to the issue picker for the now open-sourced **PSDesiredStateConfiguration** module on GitHub
- Adds an override for the v1.1 docs to continue to point at the generic feedback hub instructions
- Fixes [AB#5130](https://dev.azure.com/content-learn/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/5130)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide