### PR TITLE
Fix incorrect resource name in example

### DIFF
--- a/dsc/docs-conceptual/dsc-1.1/resources/resources.md
+++ b/dsc/docs-conceptual/dsc-1.1/resources/resources.md
@@ -89,7 +89,7 @@ Configuration TestConfig
     {
         # The name of this resource block, can be anything you choose, as l
         # ong as it is of type [String] as indicated by the schema.
-        Service "Spooler:Running"
+        Service "Spooler - Running"
         {
             Name = "Spooler"
             State = "Running"
@@ -112,7 +112,7 @@ Configuration TestConfig
     {
         # The name of this resource block, can be anything you choose, as
         # long as it is of type [String] as indicated by the schema.
-        Service "Spooler:Running"
+        Service "Spooler - Running"
         {
             Name = "Spooler"
             State = "Running"
@@ -120,7 +120,7 @@ Configuration TestConfig
 
         # To configure a second service resource block, add another Service
         # resource block and use a unique name.
-        Service "DHCP:Running"
+        Service "DHCP - Running"
         {
             Name = "DHCP"
             State = "Running"


### PR DESCRIPTION
# PR Summary

The resource names in example are not valid. A required resource name should be in the format `[<typename>]<name>`, with alphanumeric characters, spaces, `_`, `-`, `.` and `\`.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide