### PR TITLE
(MAINT) Document reference and value types for class-based DSC Resources

### DIFF
--- a/dsc/docs-conceptual/dsc-2.0/concepts/class-based-resources.md
+++ b/dsc/docs-conceptual/dsc-2.0/concepts/class-based-resources.md
@@ -12,20 +12,20 @@ settings of a system. This article explains their structure and requirements.
 
 ## Structure of a class-based DSC Resource
 
-A class-based DSC Resource is defined as a [PowerShell class][01] in a module file (`.psm1`). The
+A class-based DSC Resource is defined as a [PowerShell class][09] in a module file (`.psm1`). The
 class-based DSC Resource doesn't have special requirements for where it's defined. You can define
 it:
 
-- In the [root module][02], like `MyModule.psm1`
-- In a [nested module][03], like `MyDscResource.psm1`
+- In the [root module][18], like `MyModule.psm1`
+- In a [nested module][17], like `MyDscResource.psm1`
 
 Regardless where the DSC Resource is defined, the DSC Resource must be listed in the
-[DscResourcesToExport][04] property of a module manifest (`.psd1`) file. The [Get-DscResource][05]
+[DscResourcesToExport][16] property of a module manifest (`.psd1`) file. The [Get-DscResource][21]
 cmdlet, the [Import-DSCResource] dynamic keyword, and DSC itself, when compiling a DSC
 Configuration, will fail if the DSC Resource isn't listed in a manifest.
 
-For more information on creating a module manifest, see [New-ModuleManifest][06]. For more
-information on the settings of a module manifest, see [about_Module_Manifests][07].
+For more information on creating a module manifest, see [New-ModuleManifest][20]. For more
+information on the settings of a module manifest, see [about_Module_Manifests][15].
 
 A class-based DSC Resource must:
 
@@ -37,7 +37,7 @@ A class-based DSC Resource must:
 
 ## The DscResource attribute
 
-The definition of the class must have the [DscResource][08] attribute. This attribute indicates that
+The definition of the class must have the [DscResource][03] attribute. This attribute indicates that
 the class defines a DSC Resource.
 
 To add the **DscResource** attribute to a class, declare it on the line immediately before the class
@@ -57,8 +57,8 @@ a class-based DSC Resource when:
 - The class doesn't have at least one **Key** property
 - The class defines a non-default constructor without defining a default constructor
 
-The **DscResource** attribute can also be specified with the [RunAsCredential][09] property to
-specify the class-based DSC Resource's behavior when using the [PsDscRunAsCredential][10] property:
+The **DscResource** attribute can also be specified with the [RunAsCredential][04] property to
+specify the class-based DSC Resource's behavior when using the [PsDscRunAsCredential][08] property:
 
 - `Optional` - A user may use the **PsDscRunAsCredential** property with this DSC Resource. This is
   the default behavior. This behavior can also be specified as `Default` instead of `Optional`.
@@ -75,7 +75,7 @@ specify the class-based DSC Resource's behavior when using the [PsDscRunAsCreden
 ## Class-based DSC Resource properties
 
 The schema of a class-based DSC Resource is defined by the properties of the class. For a property
-to be recognized as part of the schema, it must have the [DscProperty][11] attribute.
+to be recognized as part of the schema, it must have the [DscProperty][02] attribute.
 
 The definition of the **DscProperty** determines how DSC treats that property:
 
@@ -135,9 +135,9 @@ When a class-based DSC Resource instance is created, the default parameterless c
 Unless you override this behavior, the default parameterless constructor intializes every property
 to the default value for its type. If the property is defined with an explicit default, that value
 is used instead. For more information on constructors for class-based DSC Resources, see
-[Constructors](#constructors).
+[Constructors][23].
 
-Whether the property is a [reference type][n1] or a [value type][n2] determines the default value.
+Whether the property is a [reference type][07] or a [value type][06] determines the default value.
 Reference types initialize to `$null`. Value types initialize to the value specified in their
 definition.
 
@@ -199,7 +199,7 @@ initialized.
 
 ### Validation property attributes
 
-The properties of a class-based DSC Resource may also use [validation attributes][12] to constrain
+The properties of a class-based DSC Resource may also use [validation attributes][14] to constrain
 the user-specified values for a property. The validation is applied when you compile a DSC
 Configuration or call `Invoke-DSCResource`. VS Code doesn't validate the values specified in your
 DSC Configuration while you're editing it.
@@ -207,7 +207,7 @@ DSC Configuration while you're editing it.
 > [!CAUTION]
 > When using `Invoke-DscResource`, validation failures for the properties don't stop the cmdlet from
 > invoking the **Get**, **Test**, or **Set** method. To prevent the cmdlet from invoking a method
-> when the input fails a property's validation attribute, specify your [ErrorActionPreference][13]
+> when the input fails a property's validation attribute, specify your [ErrorActionPreference][19]
 > as `Stop`.
 
 Defining validation attributes for properties is simpler than implementing the same logic in a
@@ -253,12 +253,12 @@ ValidateSet attribute. Supply an argument that is in the set and then
 try the command again."
 ```
 
-For more information about the validation attributes, see [about_Functions_Advanced_Parameters][12].
+For more information about the validation attributes, see [about_Functions_Advanced_Parameters][14].
 
 ### Enum properties
 
 For a better authoring and user experience than using the **ValidateSet** attribute, you can define
-an [Enum][14] that specifies a set of valid values.
+an [Enum][13] that specifies a set of valid values.
 
 For example, you could define a **FormatOption** enum and use it as the type for the **Format**
 property of a class-based DSC Resource:
@@ -304,7 +304,7 @@ Enums are also useful for when you need to use the same property across several 
 Resources. You can define the enum once and use it everywhere you need to, whereas with a
 **ValidateSet** attribute, you need to update every DSC Resource that shares the property.
 
-For more information on enums in PowerShell, see [about_Enum][14].
+For more information on enums in PowerShell, see [about_Enum][13].
 
 ### The Ensure property
 
@@ -505,11 +505,11 @@ attribute. These properties can't be used directly with `Invoke-DscResource` or 
 Configuration. They can be used internally by the class or directly by a user creating an instance
 of the class themselves.
 
-For more information on class properties, see [about_Classes][15].
+For more information on class properties, see [about_Classes][11].
 
 ## Class-based DSC Resource methods
 
-Class-based DSC Resources must implement three [methods][16]:
+Class-based DSC Resources must implement three [methods][10]:
 
 - **Get** to retrieve the current state of the DSC Resource
 - **Test** to validate whether the DSC Resource is in the desired state
@@ -531,7 +531,7 @@ writing a class-based DSC Resource, these are the most important:
   user specifies the **Property** parameter with `Invoke-DscResource` or when defining the DSC
   Resource block in a DSC Configuration.
 
-For more information on class methods, see [about_Classes][16].
+For more information on class methods, see [about_Classes][10].
 
 The methods can call cmdlets and native commands, including ones defined in the same module as
 the class-based DSC Resource.
@@ -679,7 +679,7 @@ the parameterless constructor and then each specified property is set on the ins
 > on the system for some reason. For example a class-based DSC Resource that only works on Windows
 > might throw an exception if created on a non-Windows system.
 
-For more information about constructors, see [about_Classes][17]
+For more information about constructors, see [about_Classes][12]
 
 ### Defining a default constructor
 
@@ -722,18 +722,18 @@ MyDscResource() {
 DSC only calls the parameterless constructor. However, you can define other constructors with
 parameters if the class is used in other circumstances, such as by functions in your module.
 
-For more information on defining constructors, see [about_Classes][17]
+For more information on defining constructors, see [about_Classes][12]
 
 ## Best practices
 
 This is a non-exhaustive list of best practices for authoring high quality class-based DSC Resources
 that are idempotent, safe, and maintainable. It supplements the
-[DSC Resource authoring checklist][18], which defines more general guidance for authoring DSC
+[DSC Resource authoring checklist][01], which defines more general guidance for authoring DSC
 Resources. The practices in this section are specific to class-based DSC Resources.
 
 ### Use validation attributes
 
-If you can validate a property with one or more of the [validation attributes][12], do so. This
+If you can validate a property with one or more of the [validation attributes][14], do so. This
 validation is checked before any method is called with `Invoke-DscResource` and when you compile a
 DSC Configuration. Raising an error earlier reduces the chances that the DSC Resource will fail in
 an unpredictable way when enforcing state.
@@ -749,13 +749,13 @@ an invalid value and how the value was invalid.
 > the rest of the DSC Resource's logic to work. If the DSC Resource creates a file at that location,
 > don't validate its existence on the property declaration.
 
-If you're using any [complex properties][19], be sure to apply validation attributes to those
+If you're using any [complex properties][22], be sure to apply validation attributes to those
 subproperties as well. Those subproperties are validated at the same time as their parent property.
 
 ### Use enums instead of ValidateSet
 
 If a property of the class-based DSC Resource has a list of valid values it accepts, define it as an
-[enum property][20] instead of using the **ValidateSet** attribute.
+[enum property][24] instead of using the **ValidateSet** attribute.
 
 This gives users a better error message and makes maintenance easier if you use those values
 anywhere else in your module. Instead of having to update every cmdlet or check for that property,
@@ -817,7 +817,7 @@ properties that are `$null`.
 ### Use a custom validation attribute instead of ValidateScript
 
 For properties that require more complex validation, consider defining your own attribute that
-inherits from the [ValidateArgumentsAttribute][21] class or one of its derivatives.
+inherits from the [ValidateArgumentsAttribute][05] class or one of its derivatives.
 
 This gives you much more control over the validation of the property and the messaging for when a
 specified value fails validation.
@@ -897,7 +897,7 @@ URL that begins with 'https://'."
 
 If your DSC Resource has a property with known subproperties, create a class for it and define those
 subproperties on that class. This provides a more discoverable surface for the settings and allows
-you to apply validation on subproperties. For more information, see [Complex properties][19].
+you to apply validation on subproperties. For more information, see [complex properties][22].
 
 ### Add a Validation method if properties are interdependent
 
@@ -957,27 +957,27 @@ method or function and move the code there instead. This makes testing and maint
 Resource easier. It also makes your DSC Resource's methods easier to read and understand.
 
 <!-- Reference Links -->
-
-[01]: /powershell/module/microsoft.powershell.core/about/about_classes
-[02]: /powershell/module/microsoft.powershell.core/about/about_module_manifests#rootmodule
-[03]: /powershell/module/microsoft.powershell.core/about/about_module_manifests#nestedmodules
-[04]: /powershell/module/microsoft.powershell.core/about/about_module_manifests#dscresourcestoexport
-[05]: /powershell/module/psdesiredstateconfiguration/get-dscresource
-[06]: /powershell/module/microsoft.powershell.core/new-modulemanifest
-[07]: /powershell/module/microsoft.powershell.core/about/about_module_manifests
-[08]: /dotnet/api/system.management.automation.dscresourceattribute
-[09]: /dotnet/api/system.management.automation.dscresourceattribute.runascredential
-[10]: /powershell/dsc/configurations/runasuser?view=dsc-1.1&preserve-view=true
-[11]: /dotnet/api/system.management.automation.dscpropertyattribute
-[12]: /powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters#parameter-and-variable-validation-attributes
-[13]: /powershell/module/microsoft.powershell.core/about/about_preference_variables#erroractionpreference
-[14]: /powershell/module/microsoft.powershell.core/about/about_enum
-[15]: /powershell/module/microsoft.powershell.core/about/about_classes#class-properties
-[16]: /powershell/module/microsoft.powershell.core/about/about_classes#class-methods
-[17]: /powershell/module/microsoft.powershell.core/about/about_classes#constructor
-[18]: ../how-tos/resources/authoring/checklist.md
-[19]: #complex-properties
-[20]: #enum-properties
-[21]: /dotnet/api/system.management.automation.validateargumentsattribute
-[n1]: /dotnet/csharp/language-reference/keywords/reference-types
-[n2]: /dotnet/csharp/language-reference/builtin-types/value-types
+[01]: ../how-tos/resources/authoring/checklist.md
+[02]: /dotnet/api/system.management.automation.dscpropertyattribute
+[03]: /dotnet/api/system.management.automation.dscresourceattribute
+[04]: /dotnet/api/system.management.automation.dscresourceattribute.runascredential
+[05]: /dotnet/api/system.management.automation.validateargumentsattribute
+[06]: /dotnet/csharp/language-reference/builtin-types/value-types
+[07]: /dotnet/csharp/language-reference/keywords/reference-types
+[08]: /powershell/dsc/configurations/runasuser?view=dsc-1.1&preserve-view=true
+[09]: /powershell/module/microsoft.powershell.core/about/about_classes
+[10]: /powershell/module/microsoft.powershell.core/about/about_classes#class-methods
+[11]: /powershell/module/microsoft.powershell.core/about/about_classes#class-properties
+[12]: /powershell/module/microsoft.powershell.core/about/about_classes#constructor
+[13]: /powershell/module/microsoft.powershell.core/about/about_enum
+[14]: /powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters#parameter-and-variable-validation-attributes
+[15]: /powershell/module/microsoft.powershell.core/about/about_module_manifests
+[16]: /powershell/module/microsoft.powershell.core/about/about_module_manifests#dscresourcestoexport
+[17]: /powershell/module/microsoft.powershell.core/about/about_module_manifests#nestedmodules
+[18]: /powershell/module/microsoft.powershell.core/about/about_module_manifests#rootmodule
+[19]: /powershell/module/microsoft.powershell.core/about/about_preference_variables#erroractionpreference
+[20]: /powershell/module/microsoft.powershell.core/new-modulemanifest
+[21]: /powershell/module/psdesiredstateconfiguration/get-dscresource
+[22]: #complex-properties
+[23]: #constructors
+[24]: #enum-properties

--- a/dsc/docs-conceptual/dsc-2.0/concepts/class-based-resources.md
+++ b/dsc/docs-conceptual/dsc-2.0/concepts/class-based-resources.md
@@ -153,7 +153,7 @@ that was specified as the default value.
 >
 > It isn't possible to use a class-based DSC Resource without managing every value type property
 > defined for that DSC Resource. Unlike other DSC Resources, removing a property from your DSC
-> Configuration or from the call to `Invoke-DscResource` doesn't ignore that property's state. I
+> Configuration or from the call to `Invoke-DscResource` doesn't ignore that property's state. It
 > resets it to the default.
 >
 > Only reference type properties can be unmanaged for a class-based DSC Resource.
@@ -189,13 +189,13 @@ initialized.
 
 |                     Name                      |   Type    |        Default Value        |
 | :-------------------------------------------- | :-------: | :-------------------------: |
-|               **System.String**               | Reference |           `$null`           |
-| **System.Management.Automation.PSCredential** | Reference |           `$null`           |
-|              **System.DateTime**              |   Value   | January 1, 0001 12:00:00 AM |
-|              **System.TimeSpan**              |   Value   |   All fields set to `0`.    |
 |                **System.Enum**                |   Value   |             `0`             |
 |               **System.Int32**                |   Value   |             `0`             |
 |               **System.Double**               |   Value   |             `0`             |
+|              **System.DateTime**              |   Value   | January 1, 0001 12:00:00 AM |
+|              **System.TimeSpan**              |   Value   |   All fields set to `0`.    |
+|               **System.String**               | Reference |           `$null`           |
+| **System.Management.Automation.PSCredential** | Reference |           `$null`           |
 
 ### Validation property attributes
 
@@ -763,7 +763,7 @@ you can update the enum definition.
 
 Remember that enums are value type properties. They default to `0` when an instance of the
 class-based DSC Resource is created. If you set an explicit default value for an enum property, that
-enum can't be unmanaged. If a user doesn't specify the property, the DSC Resource will behave the
+enum can't be unmanaged. If a user doesn't specify the property, the DSC Resource behaves the
 same as if the user had explicitly specified the default value.
 
 To support unmanaged enum properties, make sure not to define a label for the `0` value. By default,
@@ -781,10 +781,10 @@ enum OptionalSetting {
 }
 ```
 
-Then, in your **Test** and **Set** methods, you can ignore the enum property if the value is `0`.
-In **Test**, if the enum property is `0`, ignore the current state of the DSC Resource on the
+Then, in your `Test()` and `Set()` methods, you can ignore the enum property if the value is `0`.
+In `Test()`, if the enum property is `0`, ignore the current state of the DSC Resource on the
 system. Don't report the DSC Resource as out of desired state if the current state is a valid value.
-In **Set**, make sure your logic for modifying system state ignores the enum property if it's `0`.
+In `Set()`, make sure your logic for modifying system state ignores the enum property if it's `0`.
 
 > [!NOTE]
 > This method for implementing enum properties that can be unmanaged only works when the underlying
@@ -797,7 +797,7 @@ values for every value type property. You'll need to ensure your default values 
 those of the component your DSC Resource manages.
 
 Document the behavior of these properties for your users. Make sure that your documentation explains
-that these properties will be set to their default value if the user doesn't specify them when using
+that these properties are set to their default values if the user doesn't specify them when using
 the DSC Resource.
 
 ### Ensure the DSC Resource respects unmanaged reference type properties

--- a/dsc/docs-conceptual/dsc-2.0/concepts/class-based-resources.md
+++ b/dsc/docs-conceptual/dsc-2.0/concepts/class-based-resources.md
@@ -1,7 +1,7 @@
 ---
 description: >
   Class-based DSC Resources are a simplified implementation of DSC Resources.
-ms.date: 09/07/2022
+ms.date: 10/14/2022
 title:  Class-based DSC Resources
 ---
 
@@ -32,7 +32,7 @@ A class-based DSC Resource must:
 1. Use the **DscResource** attribute.
 1. Declare one or more properties with the **DscProperty** attribute. At least one of the properties
    must be a **Key** property.
-1. Implement the **Get**, **Test**, and **Set** methods.
+1. Implement the `Get()`, `Test()`, and `Set()` methods.
 1. Define a default constructor if it defines any alternate constructors.
 
 ## The DscResource attribute
@@ -53,7 +53,7 @@ As well as identifying the class as a DSC Resource, the **DscResource** attribut
 validation to the class-based DSC Resource. PowerShell raises a parse error for the definition of
 a class-based DSC Resource when:
 
-- One or more of the **Get**, **Test**, and **Set** methods is incorrectly defined or missing
+- One or more of the `Get()`, `Test()`, and `Set()` methods is incorrectly defined or missing
 - The class doesn't have at least one **Key** property
 - The class defines a non-default constructor without defining a default constructor
 
@@ -90,7 +90,7 @@ The definition of the **DscProperty** determines how DSC treats that property:
   `Invoke-DscResource`, the cmdlet raises an error. If any **Mandatory** properties aren't specified
   when authoring a DSC Configuration, compiling the configuration raises an error.
 - `[DscProperty(NotConfigurable)]` - Indicates that the property is **ReadOnly**. It isn't a
-  manageable setting of this DSC Resource, but will contain a value after the **Get** method of the
+  manageable setting of this DSC Resource, but will contain a value after the `Get()` method of the
   DSC Resource is called.
 - `[DscProperty()]` - Indicates that the property is a configurable setting of this DSC Resource.
   Specifying this property is optional when using `Invoke-DscResource` or authoring a DSC
@@ -125,7 +125,7 @@ It defines four properties:
 - **Settings** is a **Mandatory** property for the DSC Resource and expects to get a **Hashtable**
   for its value.
 - **LastModified** is a **ReadOnly** property for the DSC Resource and expects to get a **DateTime**
-  for its value from the **Get** method.
+  for its value from the `Get()` method.
 - **Format** is an optional property for the DSC Resource and expects to get a **String** for its
   value.
 
@@ -206,7 +206,7 @@ DSC Configuration while you're editing it.
 
 > [!CAUTION]
 > When using `Invoke-DscResource`, validation failures for the properties don't stop the cmdlet from
-> invoking the **Get**, **Test**, or **Set** method. To prevent the cmdlet from invoking a method
+> invoking the `Get()`, `Test()`, or `Set()` method. To prevent the cmdlet from invoking a method
 > when the input fails a property's validation attribute, specify your [ErrorActionPreference][19]
 > as `Stop`.
 
@@ -511,9 +511,9 @@ For more information on class properties, see [about_Classes][11].
 
 Class-based DSC Resources must implement three [methods][10]:
 
-- **Get** to retrieve the current state of the DSC Resource
-- **Test** to validate whether the DSC Resource is in the desired state
-- **Set** to enforce the desired state of the DSC Resource
+- `Get()` to retrieve the current state of the DSC Resource
+- `Test()` to validate whether the DSC Resource is in the desired state
+- `Set()` to enforce the desired state of the DSC Resource
 
 A method's _signature_ is defined by its expected output type and parameters. The class won't be
 recognized as a valid DSC Resource if it doesn't contain the correct signatures for these methods.
@@ -538,7 +538,7 @@ the class-based DSC Resource.
 
 ### Get
 
-The **Get** method is used to retrieve the current state of the DSC Resource and return it as an
+The `Get()` method is used to retrieve the current state of the DSC Resource and return it as an
 object. It must define its output as the class itself and take no parameters.
 
 For example, a class-based DSC Resource called `MyDscResource` must have this signature:
@@ -549,7 +549,7 @@ For example, a class-based DSC Resource called `MyDscResource` must have this si
 }
 ```
 
-To make the **Get** method return the correct object, you need to create an instance of the class.
+To make the `Get()` method return the correct object, you need to create an instance of the class.
 Then you can populate that instance's properties with the current values from the system. Finally,
 use the `return` keyword to output the current state.
 
@@ -568,7 +568,7 @@ use the `return` keyword to output the current state.
 }
 ```
 
-In the example implementation, the **Get** method initializes the `$CurrentState` variable with the
+In the example implementation, the `Get()` method initializes the `$CurrentState` variable with the
 default constructor for the `MyDscResource` class. It checks to see if the file specified in the
 **Path** property exists. If it does, the method sets the **Ensure** and **Path** properties on
 `$CurrentState` to `Present` and the appropriate path. If it doesn't, the method sets **Ensure** to
@@ -576,11 +576,11 @@ default constructor for the `MyDscResource` class. It checks to see if the file 
 
 ### Test
 
-The **Test** method is used to validate whether the DSC Resource is in the desired state and
+The `Test()` method is used to validate whether the DSC Resource is in the desired state and
 returns `$true` if it's in the desired state or `$false` if it isn't. It must define boolean output
 and take no parameters.
 
-The **Test** method's signature should always match this:
+The `Test()` method's signature should always match this:
 
 ```powershell
 [bool] Test() {
@@ -588,7 +588,7 @@ The **Test** method's signature should always match this:
 }
 ```
 
-Instead of reimplementing the logic from the **Get** method, call the **Get** method and assign its
+Instead of reimplementing the logic from the `Get()` method, call the `Get()` method and assign its
 output to a variable.
 
 ```powershell
@@ -607,8 +607,8 @@ output to a variable.
 }
 ```
 
-In the example implementation, the **Test** method initializes a variable, `$InDesiredState`, as
-`$true` before setting `$CurrentState` to the output of the **Get** method for the class-based DSC
+In the example implementation, the `Test()` method initializes a variable, `$InDesiredState`, as
+`$true` before setting `$CurrentState` to the output of the `Get()` method for the class-based DSC
 Resource.
 
 It then checks the values of the properties of `$CurrentState` against those specified on the DSC
@@ -620,10 +620,10 @@ statement.
 
 ### Set
 
-The **Set** method is used to enforce the desired state of the DSC Resource. It doesn't have any
+The `Set()` method is used to enforce the desired state of the DSC Resource. It doesn't have any
 output and takes no parameters.
 
-The **Set** method's signature should always match this:
+The `Set()` method's signature should always match this:
 
 ```powershell
 [void] Set() {
@@ -631,24 +631,24 @@ The **Set** method's signature should always match this:
 }
 ```
 
-The implementation of the **Set** method can't use any `return` statements. It should be written to
+The implementation of the `Set()` method can't use any `return` statements. It should be written to
 idempotently enforce the desired state.
 
 > [!NOTE]
-> You may need to retrieve the current state with the **Get** method if you need to enforce the
+> You may need to retrieve the current state with the `Get()` method if you need to enforce the
 > desired state depending on the current state of the system.
 >
 > For example, you might have logic for creating a service when it doesn't exist instead of
 > correcting an incorrect property value.
 >
-> This is also why it's important when using `Invoke-DscResource` to call the **Test** method and
-> only call the **Set** method if **Test** returns `$false`. While all DSC Resources should be
+> This is also why it's important when using `Invoke-DscResource` to call the `Test()` method and
+> only call the `Set()` method if `Test()` returns `$false`. While all DSC Resources should be
 > idempotent, you have no guarantee that any DSC Resource is truly idempotent without reviewing its
 > implementation.
 
 ### Optional methods
 
-Beyond the required **Get**, **Test**, and **Set** methods, a class-based DSC Resource can define
+Beyond the required `Get()`, `Test()`, and `Set()` methods, a class-based DSC Resource can define
 any number of additional methods. One use case for this is to define helper methods, such as for
 code used in more than one of the required methods.
 
@@ -743,7 +743,7 @@ an invalid value and how the value was invalid.
 
 > [!NOTE]
 > Only use validation attributes to ensure the user input for a property is valid, not to see
-> whether the property is in the correct state. That's what the **Test** method is for.
+> whether the property is in the correct state. That's what the `Test()` method is for.
 >
 > For example, don't validate that a **Path** value exists already unless it's required to exist for
 > the rest of the DSC Resource's logic to work. If the DSC Resource creates a file at that location,
@@ -804,14 +804,14 @@ the DSC Resource.
 
 Because reference type properties initialize to `$null`, unlike value type properties, a DSC
 Resource can distinguish between whether a reference type property was specified or not. Make sure
-that your DSC Resources ignore unmanaged reference type properties in the **Test** and **Set**
+that your DSC Resources ignore unmanaged reference type properties in the `Test()` and `Set()`
 methods.
 
-In **Test**, if the reference type property is `$null`, ignore the current state of the DSC Resource
+In `Test()`, if the reference type property is `$null`, ignore the current state of the DSC Resource
 on the system. Don't report the DSC Resource as out of desired state if the current state isn't
 `$null`.
 
-In **Set**, make sure your logic for modifying the system state ignores any reference type
+In `Set()`, make sure your logic for modifying the system state ignores any reference type
 properties that are `$null`.
 
 ### Use a custom validation attribute instead of ValidateScript
@@ -903,7 +903,7 @@ you to apply validation on subproperties. For more information, see [complex pro
 
 You may have a DSC Resource that has properties that must be combined to be validated. These
 properties can't be validated by a validation attribute. Add a validation method to your class-based
-DSC Resource and call it at the beginning of your **Get**, **Test**, and **Set** methods.
+DSC Resource and call it at the beginning of your `Get()`, `Test()`, and `Set()` methods.
 
 For example, if your DSC Resource for managing a configuration file has the **Path** and
 **Extension** properties you might need to validate:
@@ -948,7 +948,7 @@ instance fails validation.
 ```
 
 If you need to validate several different parameters or groups of parameters in this way, define a
-generic validation method that calls the others. Use that method in **Get**, **Test**, and **Set**.
+generic validation method that calls the others. Use that method in `Get()`, `Test()`, and `Set()`.
 
 ### Extract shared code into methods or functions
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation did not mention the differences between reference and value types as they apply to DSC Resources.

This change adds the _Default property values_ section, which explains the intialization of a DSC Resource's properties. Particularly, it covers their default values and how that differs between reference types and value types.

It clarifies the impact of this, namely that a DSC Resource can't know with certainty whether a value-type properties was specified as its default value or not specified at all and therefore can't be written to treat those properties as unmanaged if their default value is a valid value for that property.

It also updates the _Use enums instead of ValidateSet_ section to call out the impact this has on enums and advises readers accordingly.

Finally, it adds two new best practices sections for writing DSC Resources with the default values for reference and value type properties in mind.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide