### PR TITLE
Change src path for index.md

### DIFF
--- a/dsc/docfx.json
+++ b/dsc/docfx.json
@@ -2,7 +2,7 @@
   "build": {
     "content": [
       { "dest": "dsc", "files": [ "breadcrumb/toc.yml" ]},
-      { "dest": "dsc", "files": [ "index.md" ], "src": "dsc" },
+      { "dest": "dsc", "files": [ "index.md" ], "src": "." },
 
       { "dest": "dsc", "files": [ "**/*.md", "**/*.yml" ], "src": "docs-conceptual/dsc-1.1", "version": "dsc-1.1" },
       { "dest": "module", "exclude": [ "toc.yml" ], "files": [ "**/*.yml" ], "src": "dsc-1.1", "version": "dsc-1.1" },


### PR DESCRIPTION
Fixes [AB#28009](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/28009) - Add src path for index.md

This change should ensure that index.md gets built in the proper location so that we have a file to redirect from.