### PR TITLE
(GH-147) Fix v3 getting started examples

### DIFF
--- a/dsc/docs-conceptual/dsc-3.0/getting-started/getting-started.md
+++ b/dsc/docs-conceptual/dsc-3.0/getting-started/getting-started.md
@@ -1,6 +1,6 @@
 ---
 description: Learn how to use the Desired State Configuration feature of PowerShell to manage the state of a machine as code.
-ms.date: 01/06/2023
+ms.date: 04/04/2023
 title: Manage configuration using PowerShell DSC
 ---
 
@@ -17,7 +17,7 @@ reference a DSC resource and pass through the properties that define how to mana
 Test if the machine is in the correct state, for an example resource.
 
 ```powershell
-Invoke-DscResource @{
+$TestParameters = @{
   Name = 'Environment'
   ModuleName = 'PSDscResources'
   Property = @{
@@ -29,12 +29,13 @@ Invoke-DscResource @{
   }
   Method = Test
 }
+Invoke-DscResource @TestParameters
 ```
 
 Get the current state of a machine, for an example resource.
 
 ```powershell
-Invoke-DscResource @{
+$GetParameters = @{
   Name = 'Environment'
   ModuleName = 'PSDscResources'
   Property = @{
@@ -46,12 +47,13 @@ Invoke-DscResource @{
   }
   Method = Get
 }
+Invoke-DscResource @GetParameters
 ```
 
 Set the state of the machine, for an example resource.
 
 ```powershell
-Invoke-DscResource @{
+$SetParameters = @{
   Name = 'Environment'
   ModuleName = 'PSDscResources'
   Property = @{
@@ -63,10 +65,10 @@ Invoke-DscResource @{
   }
   Method = Set
 }
+Invoke-DscResource @SetParameters
 ```
 
-For additional details, view the
-[Invoke-DscResource][01] help.
+For more information, view the [Invoke-DscResource][01] help.
 
 ## The machine configuration feature of Azure Automanage
 


### PR DESCRIPTION


# PR Summary

Prior to this change, the example code for the v3 getting started article showed passing the parameters for `Invoke-DscResource` as a hash directly to the command.

This change fixes the examples by storing the parameter values as a hashtable in a variable and then splatting the hash table with the cmdlet execution.

- Fixes [AB#82869](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/82869)
- Resolves #147

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide