### PR TITLE
5/23 PM Publish

### DIFF
--- a/dsc/docs-conceptual/dsc-2.0/overview.md
+++ b/dsc/docs-conceptual/dsc-2.0/overview.md
@@ -14,7 +14,7 @@ of new DSC features. Users that want to continue using DSC v2 can download
 **PSDesiredStateConfiguration** 2.0.7 from the PowerShell Gallery.
 
 Users working with non-Windows environments can expect cross-platform features in DSC v3. For more
-information about the future of DSC, see the [PowerShell Team blog][1].
+information about the future of DSC, see the [PowerShell Team blog][01].
 
 To install **PSDesiredStateConfiguration** 2.0.7 from the PowerShell Gallery:
 
@@ -28,7 +28,7 @@ Install-Module -Name PSDesiredStateConfiguration -Repository PSGallery -MaximumV
 
 ## Use Case for DSC 2.0
 
-DSC 2.0 is supported for use with [Azure Automanage's machine configuration feature][2]. Other
+DSC 2.0 is supported for use with [Azure Automanage's machine configuration feature][02]. Other
 scenarios, such as directly calling DSC Resources with `Invoke-DscResource`, may be functional but
 aren't the primary intended use of this version.
 
@@ -78,7 +78,54 @@ The following features aren't supported:
 - Using composite DSC Configurations (DSC Configurations that nest another DSC Configuration inside
   them)
 
+The built-in DSC Resources have been removed. The [PSDscResources][03] module includes replacements
+for some removed DSC Resources. Refer to the following table for the status of the DSC
+Resources.
+
+|        DSC Resource         |                                     Status                                      |
+| :-------------------------- | :------------------------------------------------------------------------------ |
+| `Archive`                   | Replaced by the [Archive DSC Resource in PSDscResources][04].                   |
+| `Environment`               | Replaced by the [Environment DSC Resource in PSDscResources][05].               |
+| `File`                      | Removed. This DSC Resource isn't available in DSC v2 and later.                 |
+| `Group`                     | Replaced by the [Group DSC Resource in PSDscResources][06].                     |
+| `GroupSet`                  | Replaced by the [GroupSet DSC Resource in PSDscResources][07].                  |
+| `Log`                       | Removed. This DSC Resource isn't available in DSC v2 and later.                 |
+| `Package`                   | Partially replaced by the [MsiPackage DSC Resource in PSDscResources][08].      |
+| `ProcessSet`                | Replaced by the [ProcessSet DSC Resource in PSDscResources][09].                |
+| `Registry`                  | Replaced by the [Registry DSC Resource in PSDscResources][10].                  |
+| `Script`                    | Replaced by the [Script DSC Resource in PSDscResources][11].                    |
+| `Service`                   | Replaced by the [Service DSC Resource in PSDscResources][12].                   |
+| `ServiceSet`                | Replaced by the [ServiceSet DSC Resource in PSDscResources][13].                |
+| `User`                      | Replaced by the [User DSC Resource in PSDscResources][14].                      |
+| `WaitForAll`                | Removed. This DSC Resource isn't available in DSC v2 and later.                 |
+| `WaitForAny`                | Removed. This DSC Resource isn't available in DSC v2 and later.                 |
+| `WaitForSome`               | Removed. This DSC Resource isn't available in DSC v2 and later.                 |
+| `WindowsFeature`            | Replaced by the [WindowsFeature DSC Resource in PSDscResources][15].            |
+| `WindowsFeatureSet`         | Replaced by the [WindowsFeatureSet DSC Resource in PSDscResources][16].         |
+| `WindowsOptionalFeature`    | Replaced by the [WindowsOptionalFeature DSC Resource in PSDscResources][17].    |
+| `WindowsOptionalFeatureSet` | Replaced by the [WindowsOptionalFeatureSet DSC Resource in PSDscResources][18]. |
+| `WindowsPackageCab`         | Replaced by the [WindowsPackageCab DSC Resource in PSDscResources][19].         |
+| `WindowsProcess`            | Replaced by the [WindowsProcess DSC Resource in PSDscResources][20].            |
+
 <!-- Reference Links -->
 
-[1]: https://devblogs.microsoft.com/powershell/powershell-team-2021-investments/#dsc-for-powershell-7
-[2]: /azure/governance/machine-configuration/overview
+[01]: https://devblogs.microsoft.com/powershell/powershell-team-2021-investments/#dsc-for-powershell-7
+[02]: /azure/governance/machine-configuration/overview
+[03]: ./reference/PSDscResources/overview.md
+[04]: ./reference/PSDscResources/Resources/Archive/Archive.md
+[05]: ./reference/PSDscResources/Resources/Environment/Environment.md
+[06]: ./reference/PSDscResources/Resources/Group/Group.md
+[07]: ./reference/PSDscResources/Resources/GroupSet/GroupSet.md
+[08]: ./reference/PSDscResources/Resources/MsiPackage/MsiPackage.md
+[09]: ./reference/PSDscResources/Resources/ProcessSet/ProcessSet.md
+[10]: ./reference/PSDscResources/Resources/Registry/Registry.md
+[11]: ./reference/PSDscResources/Resources/Script/Script.md
+[12]: ./reference/PSDscResources/Resources/Service/Service.md
+[13]: ./reference/PSDscResources/Resources/ServiceSet/ServiceSet.md
+[14]: ./reference/PSDscResources/Resources/User/User.md
+[15]: ./reference/PSDscResources/Resources/WindowsFeature/WindowsFeature.md
+[16]: ./reference/PSDscResources/Resources/WindowsFeatureSet/WindowsFeatureSet.md
+[17]: ./reference/PSDscResources/Resources/WindowsOptionalFeature/WindowsOptionalFeature.md
+[18]: ./reference/PSDscResources/Resources/WindowsOptionalFeatureSet/WindowsOptionalFeatureSet.md
+[19]: ./reference/PSDscResources/Resources/WindowsPackageCab/WindowsPackageCab.md
+[20]: ./reference/PSDscResources/Resources/WindowsProcess/WindowsProcess.md


### PR DESCRIPTION
Prior to this change, it wasn't obvious to end-users that the built-in DSC Resources from v1.1 aren't available in DSC v2 and later.

This change:

- Adds information about the removed DSC Resources to the v2 overview, including linking to the replacement DSC Resources in **PSDscResources**.
- Fixes [AB#91783](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/91783)

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [ ] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [ ] **Summary:** This PR's summary describes the scope and intent of the change.
- [ ] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [ ] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide