### PR TITLE
(MAINT) Fix rendering for YAML metadata

### DIFF
--- a/dsc/docs-conceptual/dsc-3.0/reference/cli/dsc.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/cli/dsc.md
@@ -73,13 +73,10 @@ To set the output format for a command or subcommand, specify this option before
 `dsc --format pretty-json resource list`.
 
 ```yaml
-Type:          String
-Mandatory:     false
-Default Value: yaml
-Valid Values:
-  - json
-  - pretty-json
-  - yaml
+Type:         String
+Mandatory:    false
+DefaultValue: yaml
+ValidValues:  [json, pretty-json, yaml]
 ```
 
 ### -h, --help

--- a/dsc/docs-conceptual/dsc-3.0/reference/cli/schema/command.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/cli/schema/command.md
@@ -73,18 +73,19 @@ schema the application returns:
   `dsc config test` command.
 
 ```yaml
-Type:      String
-Mandatory: true
-Valid Values:
-  - dsc-resource
-  - resource-manifest
-  - get-result
-  - set-result
-  - test-result
-  - configuration
-  - configuration-get-result
-  - configuration-set-result
-  - configuration-test-result
+Type:        String
+Mandatory:   true
+ValidValues: [
+               dsc-resource,
+               resource-manifest,
+               get-result,
+               set-result,
+               test-result,
+               configuration,
+               configuration-get-result,
+               configuration-set-result,
+               configuration-test-result
+             ]
 ```
 
 ### -h, --help

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/config/document.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/config/document.md
@@ -14,9 +14,9 @@ The YAML or JSON file that defines a DSC Configuration.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+Type:          object
 ```
 
 ## Description
@@ -55,11 +55,12 @@ adheres to. DSC uses this property when validating the configuration document be
 configuration operations.
 
 ```yaml
-Type:     string
-Required: true
-Format:   URI
-Valid Values:
-  - https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+Type:        string
+Required:    true
+Format:      URI
+ValidValues: [
+               https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+             ]
 ```
 
 ### metadata
@@ -90,9 +91,9 @@ For more information about defining parameters in a configuration, see
 [DSC Configuration parameters][03] -->
 
 ```yaml
-Type:                  object
-Required:              false
-Valid Property Schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.parameter.json
+Type:                object
+Required:            false
+ValidPropertySchema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.parameter.json
 ```
 
 ### variables
@@ -125,10 +126,10 @@ For more information about defining a valid resource instance in a configuration
 [DSC Configuration resources][06] and [DSC Configuration resource groups][07]. -->
 
 ```yaml
-Type:               array
-Required:           true
-Minimum Item Count: 1
-Valid Item Schema:  https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.resource.json
+Type:             array
+Required:         true
+MinimumItemCount: 1
+ValidItemSchema:  https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.resource.json
 ```
 
 <!-- [01]: ../../../configurations/overview.md -->

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/config/parameter.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/config/parameter.md
@@ -14,9 +14,9 @@ Defines runtime options for a configuration.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.parameter.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.parameter.json
+Type:          object
 ```
 
 ## Description
@@ -75,16 +75,9 @@ For more information about data types, see
 [DSC configuration parameter data type schema reference][02].
 
 ```yaml
-Type:     string
-Required: true
-Valid Values:
-  - string
-  - securestring
-  - int
-  - bool
-  - object
-  - secureobject
-  - array
+Type:        string
+Required:    true
+ValidValues: [string, securestring, int, bool, object, secureobject, array]
 ```
 
 ### defaultValue
@@ -95,13 +88,8 @@ runtime and no default value is defined, DSC raises an error. The value must be 
 parameter's `type`.
 
 ```yaml
-Required: false
-Valid JSON Types:
-  - string
-  - integer
-  - object
-  - array
-  - boolean
+Required:       false
+ValidJSONTypes: [string, integer, object, array, boolean]
 ```
 
 ### allowedValues
@@ -114,14 +102,9 @@ This property is always an array. If this property is defined, it must include a
 the list of values.
 
 ```yaml
-Type:     array
-Required: false
-Valid Item JSON Types:
-  - string
-  - integer
-  - object
-  - array
-  - boolean
+Type:               array
+Required:           false
+ValidItemJSONTypes: [string, integer, object, array, boolean]
 ```
 
 ### minLength
@@ -137,9 +120,9 @@ If this property is defined with the `maxLength` property, this property must be
 `maxLength`. If it isn't, DSC raises an error.
 
 ```yaml
-Type:          int
-Required:      false
-Minimum Value: 0
+Type:         int
+Required:     false
+MinimumValue: 0
 ```
 
 ### maxLength
@@ -155,9 +138,9 @@ If this property is defined with the `minLength` property, this property must be
 `minLength`. If it isn't, DSC raises an error.
 
 ```yaml
-Type:          int
-Required:      false
-Minimum Value: 0
+Type:         int
+Required:     false
+MinimumValue: 0
 ```
 
 ### minValue

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/config/resource.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/config/resource.md
@@ -14,9 +14,9 @@ Defines a DSC Resource instance in a configuration document.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.resource.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.resource.json
+Type:          object
 ```
 
 ## Description
@@ -96,11 +96,11 @@ unique in that instance's `dependsOn` property.
 <!-- For more information, see [Configuration resource dependencies][04]. -->
 
 ```yaml
-Type:                 array
-Required:             false
-Items Must be Unique: true
-Valid Items Type:     string
-Valid Items Pattern:  ^\[\w+(\.\w+){0,2}\/\w+\].+$
+Type:              array
+Required:          false
+ItemsMustBeUnique: true
+ItemsType:         string
+ItemsPattern:      ^\[\w+(\.\w+){0,2}\/\w+\].+$
 ```
 
 [01]: ../definitions/resourceType.md

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/definitions/message.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/definitions/message.md
@@ -14,9 +14,9 @@ A message emitted by a DSC Resource with associated metadata.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/message.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/message.json
+Type:          object
 ```
 
 ## Description
@@ -67,12 +67,9 @@ Required: true
 Indicates the severity of the message.
 
 ```yaml
-Type:     string
-Required: true
-Valid Values:
-  - Error
-  - Warning
-  - Information
+Type:         string
+Required:     true
+Valid Values: [Error, Warning, Information]
 ```
 
 [01]: resourceType.md

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/definitions/parameters/dataTypes.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/definitions/parameters/dataTypes.md
@@ -14,17 +14,10 @@ Defines valid data types for a DSC configuration parameter
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/parameters/dataTypes.json
-Type           : string
-Valid Values:
-  - array
-  - bool
-  - int
-  - object
-  - string
-  - secureobject
-  - securestring
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/parameters/dataTypes.json
+Type:          string
+ValidValues:   [array, bool, int, object, string, secureobject, securestring]
 ```
 
 ## Description

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/definitions/resourceType.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/definitions/resourceType.md
@@ -14,10 +14,10 @@ Identifies a DSC Resource.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/resourceType.json
-Type           : string
-Pattern        : ^\w+(\.\w+){0,2}\/\w+$
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/resourceType.json
+Type:          string
+Pattern:       ^\w+(\.\w+){0,2}\/\w+$
 ```
 
 ## Description

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/outputs/config/get.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/outputs/config/get.md
@@ -14,9 +14,9 @@ The result output from the `dsc config get` command.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/config/get.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/config/get.json
+Type:          object
 ```
 
 ## Description
@@ -41,9 +41,9 @@ configuration document. Every entry in the list includes the resource's type nam
 and the result data for an instance.
 
 ```yaml
-Type:     array
-Required: true
-Items Type: object
+Type:      array
+Required:  true
+ItemsType: object
 ```
 
 #### type

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/outputs/config/set.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/outputs/config/set.md
@@ -14,9 +14,9 @@ The result output from the `dsc config set` command.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/config/set.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/config/set.json
+Type:          object
 ```
 
 ## Description
@@ -42,9 +42,9 @@ configuration document. Every entry in the list includes the resource's type nam
 and the result data for an instance.
 
 ```yaml
-Type:     array
-Required: true
-Items Type: object
+Type:      array
+Required:  true
+ItemsType: object
 ```
 
 #### type

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/outputs/config/test.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/outputs/config/test.md
@@ -14,9 +14,9 @@ The result output from the `dsc config test` command.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/config/test.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/config/test.json
+Type:          object
 ```
 
 ## Description
@@ -42,9 +42,9 @@ configuration document. Every entry in the list includes the resource's type nam
 and the result data for an instance.
 
 ```yaml
-Type:     array
-Required: true
-Items Type: object
+Type:      array
+Required:  true
+ItemsType: object
 ```
 
 #### type

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/outputs/resource/get.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/outputs/resource/get.md
@@ -14,9 +14,9 @@ The result output from the `dsc resource get` command.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/get.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/get.json
+Type:          object
 ```
 
 ## Description

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/outputs/resource/list.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/outputs/resource/list.md
@@ -14,9 +14,9 @@ The result output from the `dsc resource list` command.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/list.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/list.json
+Type:          object
 ```
 
 ## Description
@@ -133,10 +133,10 @@ resources, this property is an empty array.
 -->
 
 ```yaml
-Type:          array
-Required:      true
-Items Type:    string
-Items Pattern: ^\w+$
+Type:         array
+Required:     true
+ItemsType:    string
+ItemsPattern: ^\w+$
 ```
 
 ### requires

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/outputs/resource/set.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/outputs/resource/set.md
@@ -14,9 +14,9 @@ The result output from the `dsc resource set` command.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/set.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/set.json
+Type:          object
 ```
 
 ## Description
@@ -60,7 +60,7 @@ Defines the names of the properties the set operation enforced. If this value is
 the resource made no changes during the set operation.
 
 ```yaml
-Type:       array
-Required:   true
-Items Type: string
+Type:      array
+Required:  true
+ItemsType: string
 ```

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/outputs/resource/test.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/outputs/resource/test.md
@@ -14,9 +14,9 @@ The result output from the `dsc resource test` command.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/test.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/test.json
+Type:          object
 ```
 
 ## Description
@@ -68,7 +68,7 @@ Defines the names of the properties that aren't in the desired state. If this va
 array, the instance's properties are in the desired state.
 
 ```yaml
-Type:       array
-Required:   true
-Items Type: string
+Type:      array
+Required:  true
+ItemsType: string
 ```

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/get.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/get.md
@@ -14,9 +14,9 @@ Defines how to retrieve a DSC Resource instance.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.get.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.get.json
+Type:          object
 ```
 
 ## Description
@@ -112,10 +112,8 @@ be one of the following strings:
 - `stdin` - Indicates that the resource expects a JSON blob representing an instance from `stdin`.
 
 ```yaml
-Type:     string
-Required: false
-Default:  stdin
-Valid Values:
-  - args
-  - stdin
+Type:        string
+Required:    false
+Default:     stdin
+ValidValues: [args, stdin]
 ```

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/provider.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/provider.md
@@ -14,9 +14,9 @@ Defines a DSC Resource as a DSC Resource Provider.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.provider.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.provider.json
+Type:          object
 ```
 
 ## Description
@@ -85,10 +85,8 @@ value must be one of the following options:
   a [JSON Line][01] over `stdin`.
 
 ```yaml
-Type: string
-Valid Values:
-  - full
-  - sequence
+Type:        string
+ValidValues: [full, sequence]
 ```
 
 ### list
@@ -97,10 +95,9 @@ The `list` property defines how to call the provider to list the resources it su
 of this property must be an object and define the `executable` subproperty.
 
 ```yaml
-Type:     object
-Required: true
-Required Properties:
-  - executable
+Type:               object
+Required:           true
+RequiredProperties: [executable]
 ```
 
 #### executable

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/root.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/root.md
@@ -14,9 +14,9 @@ The JSON file that defines a command-based DSC Resource.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.json
+Type:          object
 ```
 
 ## Description
@@ -47,11 +47,10 @@ manifest validates against. This property is mandatory. DSC uses this value to v
 manifest against the correct JSON schema.
 
 ```yaml
-Type:     string
-Required: true
-Pattern:  ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
-Valid Values:
-  - '1.0'
+Type:        string
+Required:    true
+Pattern:     ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+ValidValues: ['1.0']
 ```
 
 ### type
@@ -95,12 +94,11 @@ property must be an array of strings. Each tag must contain only alphanumeric ch
 underscores. No other characters are permitted. Each tag must be unique.
 
 ```yaml
-Type:     array
-Required: false
-Valid Items:
-  Type:    string
-  Pattern: ^\w+$
-  Unique:  true
+Type:              array
+Required:          false
+ItemsMustBeUnique: true
+ItemsType:         string
+ItemsPattern:      ^\w+$
 ```
 
 ### get
@@ -182,11 +180,10 @@ Define this property as a set of key-value pairs where:
 DSC interprets exit code `0` as a successful operation and any other exit code as an error.
 
 ```yaml
-Type:     object
-Required: false
-Valid Properties:
-  Name Pattern: ^[0-9]+#
-  Value Type:   string
+Type:                object
+Required:            false
+PropertyNamePattern: ^[0-9]+#
+PropertyValueType:   string
 ```
 
 ### schema

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/schema/embedded.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/schema/embedded.md
@@ -14,9 +14,9 @@ Defines a JSON Schema that validates a DSC Resource instance.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.schema.json#/properties/embedded
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.schema.json#/properties/embedded
+Type:          object
 ```
 
 ## Description
@@ -47,13 +47,14 @@ how to interpret them.
 DSC only supports JSON Schema Draft 07 and later.
 
 ```yaml
-Type:     string
-Required: true
-Format:   uri-reference
-Valid Values:
-  - https://json-schema.org/draft/2020-12/schema
-  - https://json-schema.org/draft/2019-09/schema
-  - http://json-schema.org/draft-07/schema#
+Type:        string
+Required:    true
+Format:      uri-reference
+ValidValues: [
+                https://json-schema.org/draft/2020-12/schema
+                https://json-schema.org/draft/2019-09/schema
+                http://json-schema.org/draft-07/schema#
+              ]
 ```
 
 ### $id
@@ -73,9 +74,9 @@ The `type` keyword defines what kind of value the instance is. Instances must be
 keyword to `object`.
 
 ```yaml
-Type:        string
-Required:    true
-Valid Value: object
+Type:       string
+Required:   true
+ValidValue: object
 ```
 
 ### properties

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/schema/property.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/schema/property.md
@@ -14,9 +14,9 @@ Defines how to retrieve the JSON Schema that validates a DSC Resource instance.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.schema.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.schema.json
+Type:          object
 ```
 
 ## Description
@@ -108,9 +108,8 @@ authoring tools and other integrating applications to validate instances without
 command locally.
 
 ```yaml
-Type:     object
-Required Properties:
-  - executable
+Type:               object
+RequiredProperties: [executable]
 ```
 
 #### executable
@@ -143,8 +142,8 @@ Resource. The value for this property must be a valid JSON schema that defines t
 `type`, and `properties` keywords.
 
 ```yaml
-Type: object
-Minimum Property Count: 1
+Type:                 object
+MinimumPropertyCount: 1
 ```
 
 ### url

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/set.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/set.md
@@ -14,9 +14,9 @@ Defines how to enforce state for a DSC Resource instance.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.set.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.set.json
+Type:          object
 ```
 
 ## Description
@@ -109,12 +109,10 @@ be one of the following strings:
   `stdin`.
 
 ```yaml
-Type:     string
-Required: false
-Default:  stdin
-Valid Values:
-  - args
-  - stdin
+Type:        string
+Required:    false
+Default:     stdin
+ValidValues: [args, stdin]
 ```
 
 ### preTest
@@ -143,10 +141,8 @@ property must be one of the following strings:
 The default value is `state`.
 
 ```yaml
-Type: string
-Required: false
-Default:  state
-Valid Values:
-  - state
-  - stateAndDiff
+Type:        string
+Required:    false
+Default:     state
+ValidValues: [state, stateAndDiff]
 ```

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/test.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/test.md
@@ -14,9 +14,9 @@ Defines how to test whether a DSC Resource instance is in the desired state.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.test.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.test.json
+Type:          object
 ```
 
 ## Description
@@ -117,12 +117,10 @@ be one of the following strings:
   `stdin`.
 
 ```yaml
-Type:     string
-Required: false
-Default:  stdin
-Valid Values:
-  - args
-  - stdin
+Type:        string
+Required:    false
+Default:     stdin
+ValidValues: [args, stdin]
 ```
 
 ### return
@@ -137,10 +135,8 @@ property must be one of the following strings:
 The default value is `state`.
 
 ```yaml
-Type: string
-Required: false
-Default:  state
-Valid Values:
-  - state
-  - stateAndDiff
+Type:        string
+Required:    false
+Default:     state
+ValidValues: [state, stateAndDiff]
 ```

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/validate.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/validate.md
@@ -14,9 +14,9 @@ This property
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.validate.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.validate.json
+Type:          object
 ```
 
 ## Description

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/properties/ensure.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/properties/ensure.md
@@ -14,10 +14,10 @@ Indicates whether an instance should exist.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/ensure.json
-Type           : string
-Valid Values   : [Absent, Present]
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/ensure.json
+Type:          string
+ValidValues:   [Absent, Present]
 ```
 
 ## Description

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/properties/inDesiredState.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/properties/inDesiredState.md
@@ -14,10 +14,10 @@ Indicates whether an instance is in the desired state.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/inDesiredState.json
-Type           : [boolean, 'null']
-Read Only      : true
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/inDesiredState.json
+Type:          [boolean, 'null']
+ReadOnly:      true
 ```
 
 ## Description

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/properties/purge.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/properties/purge.md
@@ -14,10 +14,10 @@ Indicates that the resource should treat non-defined entries in a list as invali
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/purge.json
-Type           : [boolean, 'null']
-Write Only     : true
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/purge.json
+Type:          [boolean, 'null']
+WriteOnly:     true
 ```
 
 ## Description

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/properties/rebootRequested.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/properties/rebootRequested.md
@@ -14,10 +14,10 @@ Indicates whether an instance is in the desired state.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/rebootRequested.json
-Type           : [boolean, 'null']
-Read Only      : true
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/rebootRequested.json
+Type:          [boolean, 'null']
+ReadOnly:      true
 ```
 
 ## Description


### PR DESCRIPTION
# PR Summary

Prior to this change, the metadata YAML blocks for schemas and CLI parameters included spaces in the keyword names, aligned colons, and used block syntax.

The platform does not render keywords correctly when they include spaces or when there is space between the keyword and the colon.

This change standardizes the formatting so that keywords are correctly highlighted. It also switches to using flow syntax for arrays, keeping them on one line if the array fits or breaking across indented lines otherwise.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide