### PR TITLE
Fixed typo - `REG-BINARY` changed to `REG_BINARY`

### DIFF
--- a/dsc/docs-conceptual/dsc-1.1/reference/resources/windows/registryResource.md
+++ b/dsc/docs-conceptual/dsc-1.1/reference/resources/windows/registryResource.md
@@ -39,7 +39,7 @@ Registry [string] #ResourceName
 |Force |If the specified registry key is present, **Force** overwrites it with the new value. If deleting a registry key with subkeys, this needs to be `$true`. |
 |Hex |Indicates if data will be expressed in hexadecimal format. If specified, the DWORD/QWORD value data is presented in hexadecimal format. Not valid for other types. The default value is `$false`. |
 |ValueData |The data for the registry value. |
-|ValueType |Indicates the type of the value. The supported types are: **String** (REG_SZ), **Binary** (REG-BINARY), **Dword** (32-bit REG_DWORD), **Qword** (64-bit REG_QWORD), **MultiString** (REG_MULTI_SZ), **ExpandString** (REG_EXPAND_SZ). |
+|ValueType |Indicates the type of the value. The supported types are: **String** (REG_SZ), **Binary** (REG_BINARY), **Dword** (32-bit REG_DWORD), **Qword** (64-bit REG_QWORD), **MultiString** (REG_MULTI_SZ), **ExpandString** (REG_EXPAND_SZ). |
 
 ## Common properties
 


### PR DESCRIPTION
# PR Summary

Fixed typo - `REG-BINARY` changed to `REG_BINARY`. The underscore is documented at [Registry Value Types - Microsoft Learn](https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide