### PR TITLE
(GH-224) Discourage use of `Script` resource

### DIFF
--- a/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/Script/Script.md
+++ b/dsc/docs-conceptual/dsc-2.0/reference/PSDscResources/Resources/Script/Script.md
@@ -1,6 +1,6 @@
 ---
 description: PSDscResources Script resource
-ms.date: 08/08/2022
+ms.date: 12/01/2023
 ms.topic: reference
 title: Script
 ---
@@ -32,7 +32,6 @@ specific DSC resource isn't available. You must provide the code for these metho
 dependencies, and ensure your code is idempotent.
 
 > [!TIP]
-
 > Where possible, it's best practice to use a defined DSC resource instead of this one. The `Script`
 > resource has drawbacks that make it more difficult to test, maintain, and predict.
 >
@@ -41,6 +40,9 @@ dependencies, and ensure your code is idempotent.
 > no guarantees that this resource is implemented idempotently or that it'll work as expected on
 > any system because it uses custom code. It can't be tested without being invoked on a target
 > system.
+>
+> Before using the `Script` resource, consider whether you can [author a resource][01] instead.
+> Using well-defined DSC resources makes your configurations more readable and maintainable.
 
 ### Requirements
 
@@ -76,7 +78,7 @@ Type: System.String
 ### TestScript
 
 Specify a PowerShell scriptblock that validates whether the resource is in the desired state. This
-script block runs when the **Test** mothod for this resource is invoked.
+script block runs when the **Test** method for this resource is invoked.
 
 This script block should return `$true` if the resource is in the desired state and `$false` if it
 isn't in the desired state.
@@ -108,8 +110,9 @@ Type: System.String
 
 ## Examples
 
-- [Create a file with content][1]
+- [Create a file with content][02]
 
 <!-- Reference Links -->
 
-[1]: Example.md
+[01]: ../../../../how-tos/resources/authoring/overview.md
+[02]: Example.md


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation for the built-in `Script` resource made no mention of the drawbacks to using the resource and didn't direct readers to consider implementing their own resource instead.

This change:

- Updates the note for the `Script` resource in the **PSDscResources** module to explicitly suggest readers implement a custom resource.
- Adds the same note with the information about the drawbacks of the `Script` resource to the v1.1 built-in resource documentation.
- Resolves #224
- Fixes [AB#187561](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/187561)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide