### PR TITLE
(GH-233) Add `Import-DSCResource`

### DIFF
--- a/dsc/docs-conceptual/dsc-1.1/reference/resources/packagemanagement/PackageManagementDscResource.md
+++ b/dsc/docs-conceptual/dsc-1.1/reference/resources/packagemanagement/PackageManagementDscResource.md
@@ -81,6 +81,8 @@ PowerShell, respectively).
 ```powershell
 Configuration PackageTest
 {
+    Import-DscResource -ModuleName 'PackageManagement'
+
     PackageManagementSource SourceRepository
     {
         Ensure      = "Present"

--- a/dsc/docs-conceptual/dsc-1.1/reference/resources/packagemanagement/PackageManagementSourceDscResource.md
+++ b/dsc/docs-conceptual/dsc-1.1/reference/resources/packagemanagement/PackageManagementSourceDscResource.md
@@ -66,6 +66,8 @@ DSC resource.
 ```powershell
 Configuration PackageManagementSourceTest
 {
+    Import-DscResource -ModuleName 'PackageManagement'
+
     PackageManagementSource SourceRepository
     {
         Ensure      = "Present"

--- a/dsc/docs-conceptual/dsc-1.1/reference/resources/windows/fileResource.md
+++ b/dsc/docs-conceptual/dsc-1.1/reference/resources/windows/fileResource.md
@@ -103,6 +103,8 @@ The source directory is a UNC path (`\\PullServer\DemoSource`) shared from the P
 ```powershell
 Configuration FileResourceDemo
 {
+    Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
+
     Node "localhost"
     {
         File DirectoryCopy

--- a/dsc/docs-conceptual/dsc-1.1/reference/resources/windows/packageResource.md
+++ b/dsc/docs-conceptual/dsc-1.1/reference/resources/windows/packageResource.md
@@ -64,6 +64,8 @@ product ID.
 ```powershell
 Configuration PackageTest
 {
+    Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
+
     Package PackageExample
     {
         Ensure      = "Present"  # You can also set Ensure to "Absent"

--- a/dsc/docs-conceptual/dsc-1.1/reference/resources/windows/registryResource.md
+++ b/dsc/docs-conceptual/dsc-1.1/reference/resources/windows/registryResource.md
@@ -62,6 +62,8 @@ This example ensures that the registry value "TestValue" under a key named "Exam
 ```powershell
 Configuration RegistryTest
 {
+    Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
+
     Registry RegistryExample
     {
         Ensure      = "Present"  # You can also set Ensure to "Absent"
@@ -79,6 +81,8 @@ This example ensures that a key named "ExampleKey2" is present in the **HKEY\_LO
 ```powershell
 Configuration RegistryTest
 {
+    Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
+
     Registry RegistryExample
     {
         Ensure      = "Present"  # You can also set Ensure to "Absent"

--- a/dsc/docs-conceptual/dsc-1.1/reference/resources/windows/serviceResource.md
+++ b/dsc/docs-conceptual/dsc-1.1/reference/resources/windows/serviceResource.md
@@ -65,6 +65,7 @@ Service [string] #ResourceName
 configuration ServiceTest
 {
     Import-DscResource -ModuleName PSDesiredStateConfiguration
+
     Node localhost
     {
 

--- a/dsc/docs-conceptual/dsc-1.1/reference/resources/windows/serviceSetResource.md
+++ b/dsc/docs-conceptual/dsc-1.1/reference/resources/windows/serviceSetResource.md
@@ -63,6 +63,7 @@ The following configuration starts the "Windows Audio" and "Remote Desktop Servi
 configuration ServiceSetTest
 {
     Import-DscResource -ModuleName PSDesiredStateConfiguration
+
     Node localhost
     {
         ServiceSet ServiceSetExample

--- a/dsc/docs-conceptual/dsc-1.1/reference/resources/windows/windowsFeatureSetResource.md
+++ b/dsc/docs-conceptual/dsc-1.1/reference/resources/windows/windowsFeatureSetResource.md
@@ -64,6 +64,7 @@ all subfeatures of each, are installed.
 configuration FeatureSetTest
 {
     Import-DscResource -ModuleName PSDesiredStateConfiguration
+
     Node localhost
     {
 


### PR DESCRIPTION
# PR Summary

Add missing `Import-DSCResource` statements to all configuration blocks in examples.

- Resolves #233
- Fixes [AB#196403](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/196403)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide