### PR TITLE
(GH-258) Clarify `Invoke-DscResource` is incompatible with composite resources

### DIFF
--- a/dsc/dsc-1.1/PSDesiredStateConfiguration/Invoke-DscResource.md
+++ b/dsc/dsc-1.1/PSDesiredStateConfiguration/Invoke-DscResource.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.Windows.DSC.CoreConfProviders.dll-Help.xml
 Locale: en-US
 Module Name: PSDesiredStateConfiguration
-ms.date: 10/04/2021
+ms.date: 05/15/2024
 online version: https://learn.microsoft.com/powershell/module/psdesiredstateconfiguration/invoke-dscresource?view=dsc-1.1&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-DscResource
@@ -29,6 +29,9 @@ Configuration Manager (LCM) to Disabled.
 This cmdlet invokes a DSC resource directly, without creating a configuration document. Using this
 cmdlet, configuration management products can manage windows by using DSC resources. This cmdlet
 also enables debugging of resources when the DSC engine or LCM is running with debugging enabled.
+
+This cmdlet doesn't work with composite resources. Composite resources are parameterized
+configurations. Using composite resources requires the LCM.
 
 ## EXAMPLES
 

--- a/dsc/dsc-2.0/PSDesiredStateConfiguration/Invoke-DscResource.md
+++ b/dsc/dsc-2.0/PSDesiredStateConfiguration/Invoke-DscResource.md
@@ -2,7 +2,7 @@
 external help file: PSDesiredStateConfiguration-help.xml
 Locale: en-US
 Module Name: PSDesiredStateConfiguration
-ms.date: 03/21/2023
+ms.date: 05/15/2024
 online version: https://learn.microsoft.com/powershell/module/psdesiredstateconfiguration/invoke-dscresource?view=dsc-2.0&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-DscResource
@@ -27,6 +27,9 @@ The `Invoke-DscResource` cmdlet runs a method of a specified PowerShell Desired 
 
 This cmdlet invokes a DSC resource directly, without creating a configuration document. Using this
 cmdlet, configuration management products can manage windows or Linux with DSC resources.
+
+This cmdlet doesn't work with composite resources. Composite resources are parameterized
+configurations. Using composite resources requires the LCM.
 
 > [!NOTE]
 > Before PSDesiredStateConfiguration 2.0.6, using `Invoke-DscResource` in PowerShell 7 requires

--- a/dsc/dsc-3.0/PSDesiredStateConfiguration/Invoke-DscResource.md
+++ b/dsc/dsc-3.0/PSDesiredStateConfiguration/Invoke-DscResource.md
@@ -2,7 +2,7 @@
 external help file: PSDesiredStateConfiguration-help.xml
 Locale: en-US
 Module Name: PSDesiredStateConfiguration
-ms.date: 03/21/2023
+ms.date: 05/15/2024
 online version: https://learn.microsoft.com/powershell/module/psdesiredstateconfiguration/invoke-dscresource?view=dsc-3.0&WT.mc_id=ps-gethelp
 schema: 2.0.0
 title: Invoke-DscResource
@@ -27,6 +27,9 @@ The `Invoke-DscResource` cmdlet runs a method of a specified PowerShell Desired 
 
 This cmdlet invokes a DSC resource directly, without creating a configuration document. Using this
 cmdlet, configuration management products can manage windows or Linux with DSC resources.
+
+This cmdlet doesn't work with composite resources. Composite resources are parameterized
+configurations. Using composite resources requires the LCM.
 
 ## EXAMPLES
 


### PR DESCRIPTION
# PR Summary

Prior to this change, the reference documentation for `Invoke-DscResource` didn't clearly state that the cmdlet is incompatible with composite resources.

This change:

- Clarifies that `Invoke-DscResource` can't be used to invoke composite resources, which require the LCM.
- Resolves #258
- Fixes [AB#255214](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/255214)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide