### PR TITLE
Adding pwsh requirement to the Microsoft/OSInfo example documentation page

### DIFF
--- a/dsc/docs-conceptual/dsc-3.0/reference/microsoft/osinfo/examples/validate-with-dsc-resource.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/microsoft/osinfo/examples/validate-with-dsc-resource.md
@@ -24,6 +24,11 @@ The `dsc resource get` command returns an instance of the resource. The `Microso
 doesn't require any instance properties to return the instance. The resource returns the available
 information for the operating system.
 
+> [!IMPORTANT]
+> The `osinfo` command and `Microsoft/OSInfo` resource require `pwsh` command on the host system.
+> For information on installing PowerShell,
+> see https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell
+
 # [Linux](#tab/linux)
 
 ```bash


### PR DESCRIPTION
The `osinfo` and `Microsoft/OSInfo` resource require `pwsh` be available on the host. This is not clearly conveyed in the documentation.

# PR Summary
The `osinfo` and `Microsoft/OSInfo` resource require `pwsh` be available on the host. This is not conveyed in the documentation. This PR adds a note about this dependency.

## PR Checklist
- [X] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
- [X] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [X] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide