### PR TITLE
Fix Get operation text

### DIFF
--- a/dsc/docs-conceptual/dsc-3.0/concepts/resources/operations.md
+++ b/dsc/docs-conceptual/dsc-3.0/concepts/resources/operations.md
@@ -22,7 +22,7 @@ The **Get** operation returns the actual state of a specific resource instance o
 
 This operation is only available for resources that have the [get capability][01].
 
-DSC invokes the **Test** operation when you use the following commands:
+DSC invokes the **Get** operation when you use the following commands:
 
 - `dsc resource get` to return the actual state for a resource instance.
 - `dsc config get` to return the actual state for every instance in a configuration document.


### PR DESCRIPTION
# PR Summary

In the Get operation section, it erroneously mentions that DSC invokes the "Test" operation. It has been changed to be the "Get" operation.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide