### PR TITLE
(GH-359) Fix resource `kind`

### DIFF
--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/definitions/resourceKind.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/definitions/resourceKind.md
@@ -22,7 +22,7 @@ ValidValues:  [resource, adapter, group, importer, exporter]
 
 ## Description
 
-DSC supports three kinds of command-based DSC Resources:
+DSC supports several kinds of command-based DSC Resources:
 
 - `resource` - Indicates that the manifest isn't for a group or adapter resource.
 - `group` - Indicates that the manifest is for a [group resource](#group-resources).

--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/root.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/resource/manifest/root.md
@@ -165,23 +165,24 @@ Required: false
 
 ### kind
 
-The `kind` property defines how DSC should handle the resource. DSC supports three kinds of
-command-based DSC Resources: `Resource`, `Group`, and `Adapter`.
+The `kind` property defines how DSC should handle the resource. DSC supports several kinds
+ofcommand-based DSC Resources: `resource`, `group`, `adapter`, `importer`, and `exporter`.
 
 When `kind` isn't defined in the resource manifest, DSC infers the value for the property. If the
 `adapter` property is defined in the resource manifest, DSC infers the value of `kind` as
-`Adapter`. If the `adapter` property isn't defined, DSC infers the value of `kind` as `Resource`.
-DSC can't infer whether a manifest is for a group resource.
+`adapter`. If the `adapter` property isn't defined, DSC infers the value of `kind` as `resource`.
+DSC can't infer whether a manifest is for a group` or importer resource.
 
 When defining a group resource, always explicitly define the `kind` property in the manifest as
-`Group`.
+`group`. When defining an importer resource, always explicitly define the `kind` property in the
+manifest as `importer`.
 
 For more information, see [DSC Resource kind schema reference][02].
 
 ```yaml
 Type:        string
 Required:    false
-ValidValues: [Resource, Adapter, Group]
+ValidValues: [resource, adapter, group, importer, exporter]
 ```
 
 ### tags


### PR DESCRIPTION
# PR Summary

Prior to this change, the resource `kind` in the root manifest reference wasn't updated to reflect the correct casing or all valid options. This change:

- Ensures that the reference in the manifest root matches the subschema reference.
- Fixes #359

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide