### PR TITLE
(AB-506290) Standardize naming in article

### DIFF
--- a/dsc/docs-conceptual/dsc-2.0/how-tos/resources/authoring/class-based.md
+++ b/dsc/docs-conceptual/dsc-2.0/how-tos/resources/authoring/class-based.md
@@ -25,13 +25,13 @@ For more information about DSC Resources, see [DSC Resources][1].
 ## Folder structure for a class Resource
 
 To implement a DSC Resource with a PowerShell class, create the following folder structure. The
-class is defined in `MyDscResource.psm1` and the module manifest is defined in `MyDscResource.psd1`.
+class is defined in `NewFile.psm1` and the module manifest is defined in `NewFile.psd1`.
 
 ```text
 $env:ProgramFiles\WindowsPowerShell\Modules (folder)
-    |- MyDscResource (folder)
-        MyDscResource.psm1
-        MyDscResource.psd1
+    |- NewFile (folder)
+        NewFile.psm1
+        NewFile.psd1
 ```
 
 ## Create the class
@@ -61,7 +61,7 @@ follows.
 [string] $content
 
 [DscProperty(NotConfigurable)]
-[MyDscResourceReason[]] $Reasons
+[NewFileReason[]] $Reasons
 ```
 
 Notice that the properties are modified by attributes. The meaning of the attributes is as follows:
@@ -90,7 +90,7 @@ If you would like to include a new type with defined properties that you can use
 DSC Resource, create a class with property types as described before.
 
 ```powershell
-class MyDscResourceReason {
+class NewFileReason {
     [DscProperty()]
     [string] $Code
 
@@ -100,7 +100,7 @@ class MyDscResourceReason {
 ```
 
 > [!NOTE]
-> The `MyDscResourceReason` class is declared here with the module's name as a prefix. While you can
+> The `NewFileReason` class is declared here with the module's name as a prefix. While you can
 > give embedded classes any name, if two or more modules define a class with the same name and are
 > both used in a configuration, PowerShell raises an exception.
 >
@@ -134,10 +134,10 @@ function Get-File {
         [String]$content
     )
 
-    $fileContent        = [MyDscResourceReason]::new()
+    $fileContent        = [NewFileReason]::new()
     $fileContent.code   = 'file:file:content'
 
-    $filePresent        = [MyDscResourceReason]::new()
+    $filePresent        = [NewFileReason]::new()
     $filePresent.code   = 'file:file:path'
 
     $ensureReturn = 'Absent'
@@ -309,7 +309,7 @@ enum ensure {
     errors raised when multiple modules with DSC Resources define the
     Reasons property for reporting when they're out-of-state.
 #>
-class MyDscResourceReason {
+class NewFileReason {
     [DscProperty()]
     [string] $Code
 
@@ -332,10 +332,10 @@ function Get-File {
         [String]$content
     )
 
-    $fileContent        = [MyDscResourceReason]::new()
+    $fileContent        = [NewFileReason]::new()
     $fileContent.code   = 'file:file:content'
 
-    $filePresent        = [MyDscResourceReason]::new()
+    $filePresent        = [NewFileReason]::new()
     $filePresent.code   = 'file:file:path'
 
     $ensureReturn = 'Absent'
@@ -502,7 +502,7 @@ class NewFile {
         about the Resource when it is present.
     #>
     [DscProperty(NotConfigurable)]
-    [MyDscResourceReason[]] $Reasons
+    [NewFileReason[]] $Reasons
 
     <#
         This method is equivalent of the Get-TargetResource script function.
@@ -628,9 +628,9 @@ A module can define multiple class-based DSC Resources. You need to declare all 
 
 ```text
 $env:ProgramFiles\PowerShell\Modules (folder)
-    |- MyDscResource (folder)
-        |- MyDscResource.psm1
-            MyDscResource.psd1
+    |- NewFile (folder)
+        |- NewFile.psm1
+            NewFile.psd1
 ```
 
 ## See Also


### PR DESCRIPTION
# PR Summary

Prior to this change, the _Authoring a class-based DSC Resource_ article inconsistently referred to `NewFile` and `MyDscResource` for the resource and module.

This change:

- Standardizes on using `NewFile` as the resource and module name.
- Fixes [AB#506290](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/506290)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide