### PR TITLE
1/14/2026 PM Publish

### DIFF
--- a/.github/workflows/targeting-valid-branch.yml
+++ b/.github/workflows/targeting-valid-branch.yml
@@ -20,3 +20,4 @@ jobs:
         uses: MicrosoftDocs/PowerShell-Docs/.github/actions/verification/authorization/v1@main
         with:
           token: ${{ github.token }}
+          authorized_accounts: learn-build-service-prod[bot]


### PR DESCRIPTION
Prior to this change, the GHA workflow for checking authorization on submitting PRs to the `live` branch didn't include the `authorized_accounts` parameter.

When you retrieve the permissions for the `learn-build-service-prod[bot]` account, the API reports that the automation account lacks all permissions.

This change adds the bot account to an allow-list to prevent the error.

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [ ] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [ ] **Summary:** This PR's summary describes the scope and intent of the change.
- [ ] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [ ] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide