### PR TITLE
docs(dsc-3.0): fix singular parameter() -> parameters() throughout dataTypes.md

### DIFF
--- a/dsc/docs-conceptual/dsc-3.0/reference/schemas/definitions/parameters/dataTypes.md
+++ b/dsc/docs-conceptual/dsc-3.0/reference/schemas/definitions/parameters/dataTypes.md
@@ -37,19 +37,19 @@ The valid data types for a parameter are:
 Access parameters in a configuration using this syntax:
 
 ```yaml
-"[parameter('<parameter-name>')]"
+"[parameters('<parameter-name>')]"
 ```
 
 In YAML, the parameter syntax needs to be enclosed in double-quotes when used as an inline value.
 If the syntax isn't quoted, YAML interprets the syntax as an array.
 
 ```yaml
-valid:  "[parameter('example')]"
+valid:  "[parameters('example')]"
 # This unquoted syntax:
-invalid: [parameter('example')]
+invalid: [parameters('example')]
 # Evaluates to this YAML:
 invalid:
-  - parameter('example')
+  - parameters('example')
 ```
 
 ## Arrays
@@ -77,7 +77,7 @@ Access items in an array can by their index. The first item in an array is index
 syntax to access an index in an array parameter:
 
 ```yaml
-"[parameter('<parameter-name>')[<index>]]"
+"[parameters('<parameter-name>')[<index>]]"
 ```
 
 ```yaml
@@ -94,14 +94,14 @@ resources:
     type: Example.Security/Group
     properties:
       groupName: operators
-      members: "[parameter('members')]"
+      members: "[parameters('members')]"
   # Use a single item in the array as the value for a resource property
   - name: Admin Group
     type: Example.Security/Group
     properties:
       groupName: admins
       members:
-        - "[parameter('members')[0]]"
+        - "[parameters('members')[0]]"
 ```
 
 ## Booleans
@@ -170,11 +170,11 @@ resources:
   # Use the base object for the property definition
   - name: TSToy
     type: TSToy.Example/gotstoy
-    properties: "[parameter('tstoy')]"
+    properties: "[parameters('tstoy')]"
   # Use dot-notation for the property definition
   - name: Windows Product Name
     type: Microsoft.Windows/Registry
-    properties: "[parameter('registryKeys').productName]"
+    properties: "[parameters('registryKeys').productName]"
   # Use dot-notation for each value in the property definition
   - name: Windows System Root
     type: Microsoft.Windows/Registry


### PR DESCRIPTION
Closes #401. The DSC template function is called `parameters()` (matching the Azure ARM-template convention), but the *Data types* reference page at `dsc/docs-conceptual/dsc-3.0/reference/schemas/definitions/parameters/dataTypes.md` writes it as `parameter()` in nine places across five code blocks, including the very first syntax example.

The issue explicitly called out the first four code blocks; this PR fixes those plus two further singular occurrences later in the Objects example (`properties: "[parameter('tstoy')]"` / `properties: "[parameter('registryKeys').productName]"`) so the whole page uses the correct spelling. `sed -n '149p' / '182p'` already used `parameters()`, so the mixed usage on the same page is the real smell — this normalises it.

No prose or example semantics changed beyond the typo.